### PR TITLE
Fixes for fb tests.

### DIFF
--- a/src/Language/Nano/Liquid/CGMonad.hs
+++ b/src/Language/Nano/Liquid/CGMonad.hs
@@ -220,8 +220,9 @@ envGetContextCast g a
   = case [c | TCast cx c <- ann_fact a, cx == cge_ctx g] of
       [ ] -> CNo
       [c] -> c
-      cs  | all isDeadCast cs -> head cs
-          | otherwise         -> die $ errorMultipleCasts (srcPos a) cs
+      cs  -> case L.find isDeadCast cs of 
+               Just dc -> dc 
+               Nothing -> die $ errorMultipleCasts (srcPos a) cs
   where
     isDeadCast CDead{} = True
     isDeadCast _       = False

--- a/tests/pos/fb/min-index-01.ts
+++ b/tests/pos/fb/min-index-01.ts
@@ -1,7 +1,27 @@
 /*@ alias IArray<T> = Array<Immutable, T> */
 
-/*@ reduce :: forall T A . (IArray<T>, callback: (x: A, y: T, n: number) => A, init:A) => A */
-function reduce<T,A>(me: T[], callback:(x: A, y: T, n: number) => A, init:A):A{
+/*  qualif GT0(n: number)        : 0 <= n      */
+/*  qualif Len(v: a, n: number)  : n < (len v) */
+/*  qualif Len(v: a)             : (len v) > 0 */
+/*  qualif Laa(v: a, n: number)  : (len v > 0) => ((0 <= n) && (n < (len v))) */ 
+
+/*@ predicate inbounds(v, a) = ((0 <= v) && (v < (len a))) */ 
+
+
+/*  reduce :: forall T A . (IArray<T>, callback: (x: A, y: T, n: number) => A, init:A) => A */
+
+/*@ reduce :: ( me      : { IArray<number> | (len v) > 0 }
+              , callback: (x: { number | inbounds(v,me)}, y: number, n: { number | inbounds(v,me)} ) => { number | inbounds(v,me)}
+              , init    : { number | inbounds(v,me)} ) 
+              => { number | inbounds(v,me)} 
+ */
+
+/*  reduce :: ( me      : IArray<number>
+              , callback: (x: number, y: number, n: number) => number
+              , init    : number) 
+              => number
+ */
+function reduce<T,A>(me: T[], callback:(x: A, y: T, n: number) => A, init:A): A {
   var res = init;
   for (var i = 0; i < me.length; i++){
     res = callback(res, me[i], i);
@@ -9,18 +29,13 @@ function reduce<T,A>(me: T[], callback:(x: A, y: T, n: number) => A, init:A):A{
   return res;
 }
 
-/*@ minIndex :: (IArray<number>) => {v:number | true} */
+/*@ minIndex :: ({ IArray<number> | (len v) > 0} ) => number */
 function minIndex(arr: number[]): number {
 
   function body(min: number, cur: number, i: number) { 
-    if (min < arr.length) {
-      return cur < arr[min] ? i : min 
-    }
-    return min;
-    //  if (cur < arr[min])
-    //      min = i;
-    //  return min;
+      return cur < arr[min] ? i : min; 
   }; 
+
   return reduce(arr, body, 0);
 }
 

--- a/tests/pos/fb/min-index-02.ts
+++ b/tests/pos/fb/min-index-02.ts
@@ -1,16 +1,16 @@
 
 /*@ alias IArray<T> = Array<Immutable, T> */
 
+
+/*@ qualif Len(v: a, n: number)  : n < (len v) */
+
 /*@ minIndex :: (IArray<number>) => {v:number | true} */
 function minIndex(arr){
+  
   function body(min: number, cur: number, i: number) { 
-
-    if (min < arr.length) {
-      return cur < arr[min] ? i : min 
-    }
-    return min;
-
+    return cur < arr[min] ? i : min 
   }; 
+
   return arr.reduce(body, 0);
 }
 


### PR DESCRIPTION
Created this to address #62 . It should also address #61 

Added `mseq` in `consWhile`, which removed the pattern match issue.

Also, dead casts override other casts when necessary, given that we don't support multiple casts on the same expression.

About removing the bounds check in `body` in: 
https://github.com/UCSD-PL/RefScript/blob/fb_fixes/tests/pos/fb/min-index-01.ts

I can't seem to get K-var inference to work (i.e. not have to spell out the refinement for `reduce`)
