### PR TITLE
Treating `e1 || e2` as a conditional expression

### DIFF
--- a/include/prelude.ts
+++ b/include/prelude.ts
@@ -156,7 +156,9 @@ declare function builtin_OpSNEq<A,B>(x: A, y: B): boolean;
 declare function builtin_OpLAnd(x: any, y: any): any;
       
 /*@ builtin_OpLOr :: 
-    /\ forall A. (x:A, y:A) => { v:A | (if (FLS(x)) then (v = y) else (v = x)) } 
+    /\ forall A. (x: undefined, y:A) => A
+    /\ forall A. (x: null, y:A) => A
+    /\ forall A. (x:A, y:A) => { v:A | ((Prop v) => (v ~~ y) && (not (Prop v) => (v ~~ x))) } 
     /\ forall A B. (x:A, y:B)  => { v:top | (Prop(v) <=> (Prop(x) || Prop(y))) }
  */
 declare function builtin_OpLOr(x: any, y: any): any;

--- a/src/Language/Nano/Liquid/Liquid.hs
+++ b/src/Language/Nano/Liquid/Liquid.hs
@@ -582,8 +582,8 @@ consExpr g (CondExpr l e e1 e2) to
         -- consCallCondExpr g' l BICondExpr (FI Nothing ((,Nothing) <$> [e,v,e1,e2])) opTy
   where
     tt       = fromMaybe tTop to
-    mkTy Nothing (TAll cv (TAll tv (TFun Nothing [B c_ tc, B t_ _, B x_ xt, B y_ yt] o r))) = 
-      TAll cv (TAll tv (TFun Nothing [B c_ tc, B t_ tTop, B x_ xt, B y_ yt] o r))
+    mkTy Nothing (TAll cv (TAll tv (TFun Nothing [B c_ tc, B t_ _   , B x_ xt, B y_ yt] o r))) = 
+                  TAll cv (TAll tv (TFun Nothing [B c_ tc, B t_ tTop, B x_ xt, B y_ yt] o r))
     mkTy _ t = t
 
 -- | super(e1,..,en)

--- a/src/Language/Nano/SSA/SSA.hs
+++ b/src/Language/Nano/SSA/SSA.hs
@@ -579,10 +579,19 @@ ssaExpr (CondExpr l c e1 e2)
        e2'      <- ssaPureExprWith θ φ e2
        return (sc, CondExpr l c' e1' e2')
 
-        
 ssaExpr (PrefixExpr l o e)
   = ssaExpr1 (PrefixExpr l o) e
 
+ssaExpr (InfixExpr l OpLOr e1 e2)
+  = do  l' <- freshenAnn l 
+        vid <- Id <$> freshenAnn l <*> (return $ "__InfixExpr_OpLOr_" ++ show (ann_id l'))
+        vr  <- VarRef <$> freshenAnn l <*> return vid
+        vd  <- VarDecl <$> freshenAnn l <*> return vid <*> return (Just e1)
+        vs  <- VarDeclStmt <$> freshenAnn l <*> return [vd]
+        (_, vs') <- ssaStmt vs
+        (ss,e') <- ssaExpr (CondExpr l vr vr e2) 
+        return  $ (vs':ss, e')
+ 
 ssaExpr (InfixExpr l o e1 e2)
   = ssaExpr2 (InfixExpr l o) e1 e2
 

--- a/src/Language/Nano/Typecheck/Typecheck.hs
+++ b/src/Language/Nano/Typecheck/Typecheck.hs
@@ -658,8 +658,8 @@ tcExpr γ (CondExpr l e e1 e2) to
   where
     args v   = FI Nothing [(e,Nothing), (v, Nothing),(e1,to),(e2,to)]
     tt       = fromMaybe tTop to
-    mkTy Nothing (TAll cv (TAll tv (TFun Nothing [B c_ tc, B t_ _, B x_ xt, B y_ yt] o r))) = 
-      TAll cv (TAll tv (TFun Nothing [B c_ tc, B t_ tTop, B x_ xt, B y_ yt] o r))
+    mkTy Nothing (TAll cv (TAll tv (TFun Nothing [B c_ tc, B t_ _   , B x_ xt, B y_ yt] o r))) = 
+                  TAll cv (TAll tv (TFun Nothing [B c_ tc, B t_ tTop, B x_ xt, B y_ yt] o r))
     mkTy _ t = t
 
 tcExpr γ e@(PrefixExpr _ _ _) _

--- a/tests/neg/operators/lor-00.ts
+++ b/tests/neg/operators/lor-00.ts
@@ -1,0 +1,8 @@
+
+
+
+/*@ foo :: (x:null, y: { number | v > 1 } ) => { number | v > 11 } */
+function foo(x,y) {
+    return x || y;      // works due to contextual type "nunber"
+}
+

--- a/tests/neg/operators/lor-02.ts
+++ b/tests/neg/operators/lor-02.ts
@@ -1,0 +1,6 @@
+
+/*@ foo :: (x: undefined + number, y: { number | v >= 0 }) => { number | true } */
+function foo(x,y) {
+    return y || x;
+}
+

--- a/tests/neg/operators/lor-03.ts
+++ b/tests/neg/operators/lor-03.ts
@@ -1,0 +1,12 @@
+
+
+
+/*@ foo :: (x: undefined + { number | v > 1}, y: { number | v > 3}) => { number | v > 2 } */
+function foo(x,y) {
+  
+    var r = x || y;
+
+    return r; 
+
+}
+

--- a/tests/neg/operators/lor-04.ts
+++ b/tests/neg/operators/lor-04.ts
@@ -1,0 +1,10 @@
+
+/*@ foo :: (x:null, y: { number | v > 1}) => { number | v > 2 } */
+function foo(x,y) {
+
+    var r = <number> (x || y);      // no contextual type here -- hence using
+                                    // the explicit cast
+
+    return r; 
+}
+

--- a/tests/pos/misc/d3_mean.ts
+++ b/tests/pos/misc/d3_mean.ts
@@ -1,0 +1,32 @@
+
+/*@ alias nat       = {number | 0 <= v}    */
+
+/*@ d3_number :: (x:number + undefined) => {v:boolean | Prop(v) => ttag(x) == "number"} */
+function d3_number(x:any):any{
+  return x != null && !isNaN(x);
+}
+ 
+/*@ d3_mean :: 
+    forall T. (array : IArray<T>, f: (T, {#nat | v < len(array)}) => number) => {number + undefined | true}
+ */
+function d3_mean(array: any, f?: any): number {
+
+  /*@ s :: number */
+  var s = 0,
+      n = array.length;
+
+  var a,
+      i = 0,
+      j = n;
+
+    while (i < n) { 
+      a = f.call(array, array[i], i);
+      if (d3_number(a)) { 
+        s = s + a; 
+      } else { 
+        --j;
+      }
+      i++;
+  }
+  if (j) {return s / j;}  else {return undefined;}  
+}

--- a/tests/pos/objects/opt-fields-00.ts
+++ b/tests/pos/objects/opt-fields-00.ts
@@ -1,0 +1,8 @@
+
+/*@ opt :: { f? : number } */
+declare var opt: { f?: number };
+
+/*@ man :: { f: number } */
+declare var man: { f: number };
+
+opt = man;

--- a/tests/pos/operators/lor-00.ts
+++ b/tests/pos/operators/lor-00.ts
@@ -1,0 +1,8 @@
+
+
+
+/*@ foo :: (x:null, y:number) => { number | true } */
+function foo(x,y) {
+    return x || y;      // works due to contextual type "nunber"
+}
+

--- a/tests/pos/operators/lor-01.ts
+++ b/tests/pos/operators/lor-01.ts
@@ -1,0 +1,8 @@
+
+
+
+/*@ foo :: (x: undefined + number, y:number) => { number | true } */
+function foo(x,y) {
+    return x || y;
+}
+

--- a/tests/pos/operators/lor-02.ts
+++ b/tests/pos/operators/lor-02.ts
@@ -1,0 +1,8 @@
+
+
+
+/*@ foo :: (x: undefined + number, y: { number | v > 0 }) => { number | true } */
+function foo(x,y) {
+    return y || x;
+}
+

--- a/tests/pos/operators/lor-03.ts
+++ b/tests/pos/operators/lor-03.ts
@@ -1,0 +1,12 @@
+
+
+
+/*@ foo :: (x: undefined + { number | v > 1}, y: { number | v > 2}) => { number | v > 0 } */
+function foo(x,y) {
+  
+    var r = x || y;
+
+    return r; 
+
+}
+

--- a/tests/pos/operators/lor-04.ts
+++ b/tests/pos/operators/lor-04.ts
@@ -1,0 +1,10 @@
+
+/*@ foo :: (x:null, y:number) => { number | true } */
+function foo(x,y) {
+
+    var r = <number> (x || y);      // no contextual type here -- hence using
+                                    // the explicit cast
+
+    return r; 
+}
+

--- a/tests/pos/scope/modules-00.ts
+++ b/tests/pos/scope/modules-00.ts
@@ -1,0 +1,62 @@
+module K {
+
+    export function foo(): void { }
+
+    class InK { }
+
+    export module L {
+
+      export function baz(): void { }
+        
+      class InKL { }
+    
+      export module M { 
+
+        class InKLM { }
+
+          export function bar(): void {
+            foo();
+            K.foo();
+
+            L.baz();
+            K.L.baz();
+          } 
+      }
+    }
+}
+
+
+class InK { }
+
+
+module K1 {
+
+    export function foo(): void { }
+
+    class InK { }
+
+    export module L {
+
+      export function baz(): void { }
+        
+      class InKL extends InK { }
+    
+      export module M { 
+
+        class InKLM { }
+
+          export function bar(): void {
+            foo();
+            K.foo();
+
+            L.baz();
+            K.L.baz();
+          } 
+      }
+    }
+}
+
+
+K.foo();
+
+K.L.M.bar();


### PR DESCRIPTION
- `e1 || e2` --->  `let _tmp = e1 in _tmp ? _tmp : e2`
- see https://github.com/UCSD-PL/RefScript/blob/fix_lor/tests/pos/operators/lor-00.ts, etc for examples
