### PR TITLE
Fix binder-capture bugs

### DIFF
--- a/include/prelude.ts
+++ b/include/prelude.ts
@@ -37,11 +37,11 @@ declare function isNaN(x:any) : boolean;
  ************************************************************************/
 
 /*@ builtin_BIBracketRef ::
-    /\ forall   A . (x_: IArray<A>, {v: number | (0 <= v && v < (len x_))}) => A
+    /\ forall   A . (x: IArray<A>, { number | [ 0 <= v; v < len x ] }) => A
     /\ forall   A . (MArray<A> , idx: number) => A + undefined
     /\ forall M A . (Array<M,A>, idx: number + undefined) => A + undefined
     /\ forall M A . (Array<M,A>, idx: undefined) => undefined
-    /\ forall   A . (o_: [Immutable] {[y: string]: A }, x_: string) => { A | hasProperty(x_,o_) } + { undefined | (not (hasProperty(x_,o_))) }
+    /\ forall   A . (o: [Immutable] {[y: string]: A }, x: string) => { A | hasProperty(x,o) } + { undefined | not (hasProperty(x,o)) }
     /\ forall M A . ([M] {[y: string]: A }, string) => A + undefined
     /\              ({ }, string) => top
  */
@@ -50,9 +50,9 @@ declare function builtin_BIBracketRef<A>(a: A[], n: number): A;
 // TODO : add case for A<AssignsFields> or A<Unique> 
 
 /*@ builtin_BIBracketAssign :: 
-    /\ forall   A . (x_: IArray<A>, {idx:number | (0 <= idx && idx < (len x_))}, val: A) => void
-    /\ forall M A . (x_: Array<M,A>, idx:number, val: A) => void
-    /\ forall M A . ([M] {[y: string]: A }, x:string, val: A) => void
+    /\ forall   A . (x: IArray<A>, { number | (0 <= v && v < (len x))}, val: A) => void
+    /\ forall M A . (Array<M,A>, number, A) => void
+    /\ forall M A . ([M] {[y: string]: A }, string, A) => void
  */
 declare function builtin_BIBracketAssign<A>(a: A[], n: number, v: A): void;
 

--- a/src/Language/Nano/Liquid/Liquid.hs
+++ b/src/Language/Nano/Liquid/Liquid.hs
@@ -907,9 +907,9 @@ consInstantiate l g fn ft ts xes
   = do  (_,its1,ot)     <- instantiateFTy l g fn ft
         ts1             <- idxMapFI (instantiateTy l g) 1 ts
         let (ts2, its2)  = balance ts1 its1
-        let (su, ts3)    = renameBinds (toList its2) (toList xes)
+        (ts3, ot')      <- subNoCapture l (toList its2) (toList xes) ot
         _               <- zipWithM_ (subType l err g) (toList ts2) ts3
-        Just <$> envAddFresh l (F.subst su ot, WriteLocal, Initialized) g
+        Just           <$> envAddFresh l (ot', WriteLocal, Initialized) g
   where
     bSyms bs             = b_sym <$> toList bs
     toList (FI x xs)     = maybeToList x ++ xs

--- a/src/Language/Nano/Typecheck/Parse.hs
+++ b/src/Language/Nano/Typecheck/Parse.hs
@@ -665,6 +665,7 @@ mkCode ss = return   (mkCode' ss)
         >>= return . scrapeQuals 
         >>=          scrapeModules
         >>= return . fixEnums
+        >>= return . fixFunBinders
         >>= return . buildCHA
     
 ---------------------------------------------------------------------------------

--- a/src/Language/Nano/Typecheck/Types.hs
+++ b/src/Language/Nano/Typecheck/Types.hs
@@ -35,7 +35,7 @@ module Language.Nano.Typecheck.Types (
   , mkUnion, mkUnionR, mkFun, mkAll, mkAnd, mkEltFunTy, mkInitFldTy, flattenUnions, mkTCons
 
   -- * Deconstructing Types
-  , bkFun, bkFunBinds, bkFunNoBinds, bkFuns, bkAll, bkAnd, bkUnion, orUndef, funTys
+  , bkFun, bkFunBinds, bkFunNoBinds, bkFuns, bkAll, bkAnd, bkUnion, orUndef, funTys, padUndefineds
   
   , rUnion, rTypeR, rTypeROpt, setRTypeR
 
@@ -224,7 +224,8 @@ padUndefineds xs yts
 
 renameBinds yts xs    = (su, [F.subst su ty | B _ ty <- yts])
   where 
-    su                = F.mkSubst $ safeZipWith "renameBinds" fSub yts xs 
+    su                = F.mkSubst suL 
+    suL               = safeZipWith "renameBinds" fSub yts xs 
     fSub yt x         = (b_sym yt, F.eVar x)
 
 

--- a/tests/pos/arrays/arr-04.ts
+++ b/tests/pos/arrays/arr-04.ts
@@ -1,12 +1,21 @@
 
-/*@ indirectIndex :: (x: IArray<number>, b: IArray<{number|((0 <= v) && (v < (len x)))}>, i: { number | ((0 <= v) && (v < (len b)))}) => number */
-function indirectIndex(x : number[], b : number[], i : number) : number {
+/*@ indirectIndex :: (x: IArray<number>,
+                      b: IArray<{ number | [ 0 <= v; v < len x ] }>, 
+                      i:        { number | [ 0 <= v; v < len b ] }
+                     ) 
+                  => number 
+ */
+function indirectIndex(x: number[], b: number[], i: number) : number {
   var bi = b[i];
   return x[bi];
-
 }
 
-/*@ writeIndex :: (x:IArray<number>, i:{ number | (0 <= v && v < (len x)) }, v: number) => void */
+/*@ writeIndex :: (x: IArray<number>, 
+                   i: { number | [ 0 <= v; v < len x ] }, 
+                   v: number
+                  ) 
+               => void 
+ */
 function writeIndex(x : number[], i : number, v: number) : void {
   x[i] = v;
   return;


### PR DESCRIPTION
Addresses bugs where function argument types contain references in their refinements with the same name as the function's formal binders.

Addresses also #105