### PR TITLE
Option for non-linear arithmetic support

### DIFF
--- a/src/Language/Nano/Annots.hs
+++ b/src/Language/Nano/Annots.hs
@@ -5,9 +5,6 @@
 {-# LANGUAGE FlexibleInstances      #-}
 {-# LANGUAGE OverlappingInstances   #-}
 
-
-
-
 module Language.Nano.Annots (
 
   -- * SSA 
@@ -25,6 +22,9 @@ module Language.Nano.Annots (
 
   -- * Deconstructing Facts
   , factRTypes
+
+  -- Options
+  , RscOption (..)
                                   
 ) where
 
@@ -114,6 +114,11 @@ castDirection (CNo  {}) = CDNo
 castDirection (CDead{}) = CDDead
 castDirection (CUp  {}) = CDUp
 castDirection (CDn  {}) = CDDn
+
+
+-----------------------------------------------------------------------------
+-- | Facts
+-----------------------------------------------------------------------------
 
 data FactQ q r
   -- SSA
@@ -255,4 +260,12 @@ factRTypes = go
     go (IfaceAnn ifd)     = f_type . snd <$> M.toList (t_elts ifd)
     go (ClassAnn (_,e,i)) = concatMap snd e ++ concatMap snd i
     go f                  = error ("factRTypes: TODO :" ++ show f)
+
+
+-----------------------------------------------------------------------------
+-- | RSC Options
+-----------------------------------------------------------------------------
+
+data RscOption = RealOption
+    deriving (Eq, Show, Data, Typeable)
 

--- a/src/Language/Nano/Liquid/Liquid.hs
+++ b/src/Language/Nano/Liquid/Liquid.hs
@@ -86,7 +86,7 @@ tc cfg next p
 
 refTc cfg f p
   = do donePhase Loud "Generate Constraints"
-       solveConstraints f cgi
+       solveConstraints p f cgi
   where
     -- cgi = generateConstraints cfg $ trace (show (ppCasts p)) p
     cgi = generateConstraints cfg p
@@ -101,20 +101,20 @@ ppCasts (Nano { code = Src fs }) =
 -- | solveConstraints
 --   Call solve with `ueqAllSorts` enabled.
 --------------------------------------------------------------------------------
-solveConstraints :: FilePath -> CGInfo -> IO (A.UAnnSol RefType, F.FixResult Error) 
+solveConstraints :: NanoRefType 
+                 -> FilePath 
+                 -> CGInfo 
+                 -> IO (A.UAnnSol RefType, F.FixResult Error) 
 --------------------------------------------------------------------------------
-solveConstraints f cgi 
-  = do (r, s)  <- solve fixpointConfig f [] $ cgi_finfo cgi
+solveConstraints p f cgi 
+  = do (r, s)  <- solve fpConf f [] $ cgi_finfo cgi
        let r'   = fmap (ci_info . F.sinfo) r
        let ann  = cgi_annot cgi
        let sol  = applySolution s 
        return (A.SomeAnn ann sol, r') 
-
-fixpointConfig  = cfg2 --  C.withUEqAllSorts def True
   where
-    cfg0        = def
-    cfg1        = cfg0 { C.real = True }
-    cfg2        = C.withUEqAllSorts cfg1 True
+    fpConf      = C.withUEqAllSorts def { C.real = real } True 
+    real        = RealOption `elem` pOptions p 
 
 --------------------------------------------------------------------------------
 applySolution :: F.FixSolution -> A.UAnnInfo RefType -> A.UAnnInfo RefType 

--- a/src/Language/Nano/Program.hs
+++ b/src/Language/Nano/Program.hs
@@ -119,7 +119,7 @@ data Nano a r = Nano {
   --
   -- ^ Options
   --
-  , pOptions  :: [String]
+  , pOptions  :: [RscOption]
 
   } deriving (Functor) -- , Data, Typeable)
 

--- a/src/Language/Nano/Typecheck/Parse.hs
+++ b/src/Language/Nano/Typecheck/Parse.hs
@@ -137,9 +137,8 @@ aliasVarT (l, x)
 -- 
 -- PV: Insert your option parser here
 --
-optionP   = do _ <- many anyToken 
-               return "DEFAULT FLAG"
-    
+optionP   = string "REALS" >> return RealOption
+
 iFaceP   :: Parser (Id SrcSpan, IfaceDefQ RK Reft)
 iFaceP   
   = do  name   <- identifierP 
@@ -529,7 +528,7 @@ data PSpec l r
   | TAlias  (Id l, TAlias (RTypeQ RK r))
   | PAlias  (Id l, PAlias) 
   | Qual    Qualifier
-  | Option  String
+  | Option  RscOption
   | Invt    l (RTypeQ RK r) 
   | CastSp  l (RTypeQ RK r)
   | Exported l

--- a/tests/neg/simple/arithmetic-option.ts
+++ b/tests/neg/simple/arithmetic-option.ts
@@ -1,0 +1,9 @@
+
+/*@ option NOTREALS */
+
+var a = 10; 
+
+var b = 20; 
+
+assert(a*a + b*b > 499);
+

--- a/tests/pos/simple/arithmetic-option.ts
+++ b/tests/pos/simple/arithmetic-option.ts
@@ -1,0 +1,9 @@
+
+/*@ option REALS */
+
+var a = 10; 
+
+var b = 20; 
+
+assert(a*a + b*b > 499);
+

--- a/tests/pos/simple/non-linear.ts
+++ b/tests/pos/simple/non-linear.ts
@@ -1,4 +1,6 @@
 
+/*@ option REALS */
+
 /*@ alias nat = {number | v >= 0} */
 
 /*@ foo :: (x:nat, y:nat) => {void | true} */


### PR DESCRIPTION
To enable add:
```
/*@ option REALS */
```
to (the beginning of) your file.

E.g. https://github.com/UCSD-PL/RefScript/blob/real-opt/tests/pos/simple/non-linear.ts