### PR TITLE
Constructor invariants

### DIFF
--- a/include/prelude.ts
+++ b/include/prelude.ts
@@ -978,6 +978,10 @@ interface InheritedMut {
 } 
 
 
+// TRY OUT offset
+/*@ measure offset :: forall A B C . (x:A, y:B) => C */
+
+
 /*************************************************************************
  *
  *      OPTIONAL FIELDS

--- a/src/Language/Nano/SSA/SSA.hs
+++ b/src/Language/Nano/SSA/SSA.hs
@@ -485,10 +485,10 @@ ctorVisitor ms            = defaultVisitor { endStmt = es } { endExpr = ee }
     ts r@(ReturnStmt l _) = BlockStmt <$> fr_ l <*> ((:[r]) <$> ctorExit l ms)
     ts r                  = return $ r
 
-ctorExit l ms =  ExprStmt  <$> fr 
-             <*> (CallExpr <$> fr
-                           <*> (VarRef <$> fr <*> freshenIdSSA (builtinOpId BICtorExit))
-                           <*> mapM ((VarRef <$> fr <*>) . return . mkCtorId l) ms)
+ctorExit l ms 
+  = do  m     <- VarRef <$> fr <*> freshenIdSSA (builtinOpId BICtorExit)
+        es    <- mapM ((VarRef <$> fr <*>) . return . mkCtorId l) ms
+        ReturnStmt <$> fr <*> (Just <$> (CallExpr <$> fr <*> return m <*> return es))
   where
     fr = fr_ l
 
@@ -514,7 +514,7 @@ ctorExit l ms =  ExprStmt  <$> fr
 --    if () { _ctor_x_2 = 2; }
 --    // _ctor_x_3 = φ(_ctor_x_2,_ctor_x_0);
 --    
---    _ctor_exit(_ctor_x_3,_ctor_y_1);
+--    return _ctor_exit(_ctor_x_3,_ctor_y_1);
 --
 --  }
 --

--- a/src/Language/Nano/Typecheck/Lookup.hs
+++ b/src/Language/Nano/Typecheck/Lookup.hs
@@ -153,7 +153,8 @@ extractCtor γ (TClass x)
   = do  d        <- resolveTypeInEnv γ x
         (vs, es) <- expand'' InstanceMember γ d
         case M.lookup (ctorSymbol, InstanceMember) es of
-          Just (ConsSig t) -> fixRet x vs t
+        -- XXX : disabling fixret for now
+          Just (ConsSig t) -> return $ mkAll vs t -- fixRet x vs t
           _                -> return $ defCtor x vs
   where
 

--- a/src/Language/Nano/Typecheck/Resolve.hs
+++ b/src/Language/Nano/Typecheck/Resolve.hs
@@ -165,6 +165,9 @@ data CoercionKind = Coercive | NonCoercive
 --    i.e. if the top-level is 'AssignsFields' then fields get Mutable
 --    (overriding their current mutability).
 --
+--    if CoercionKind == Coercive, then primitive types will be treated as their
+--    object counterparts, i.e. String, Number, Boolean. 
+--
 ---------------------------------------------------------------------------
 expandType :: (PPR r, EnvLike r g, Data r)
            => CoercionKind -> g r -> RType r -> Maybe (RType r)

--- a/tests/neg/classes/class-03.ts
+++ b/tests/neg/classes/class-03.ts
@@ -1,6 +1,8 @@
 
 class Foo<A> { 
 	public f:A;
+
+  /*@ new (x: A) => { Foo<M,A> | true } */
 	constructor(x: A) { this.f = x; }
 }
 

--- a/tests/neg/classes/class-08.ts
+++ b/tests/neg/classes/class-08.ts
@@ -1,5 +1,6 @@
 class Foo<A> { 
 	public f: A;  
+  /*@ new (x: A) => { Foo<M,A> | true } */
 	constructor(x: A) {
 		this.f = x;
 	}	

--- a/tests/neg/classes/ctor-05-0.ts
+++ b/tests/neg/classes/ctor-05-0.ts
@@ -6,6 +6,8 @@ module K {
       export class A {
         public x0 = "";
         public y0 = "";
+
+        /*@ new () => { A<M> | true } */
         constructor() {}
       }
 
@@ -19,6 +21,7 @@ module Mod {
     /*@ k : [Immutable] { string | v = "K" } */
     public k = "";  
 
+    /*@ new () => { AA<M> | true } */
     constructor() {
       super();
     }
@@ -31,6 +34,8 @@ module N {
     public l: string;
     /*@ k : [Immutable] { string | v = "KK" } */
     public k: string;
+
+    /*@ new () => { BB<M> | true } */
     constructor() {
       super();
       this.k = "KK";

--- a/tests/neg/classes/ctor-05-1.ts
+++ b/tests/neg/classes/ctor-05-1.ts
@@ -6,6 +6,7 @@ module K {
       export class A {
         public x0 = "";
         public y0 = "";
+        /*@ new () => { A<M> | true } */
         constructor() {}
       }
 
@@ -19,6 +20,7 @@ module Mod {
     /*@ k : [Immutable] { string | v = "K" } */
     public k = "K";  
 
+    /*@ new () => { AA<M> | true } */
     constructor() {
       super();
     }
@@ -31,6 +33,8 @@ module N {
     public l: string;
     /*@ k : [Immutable] { string | v = "KK" } */
     public k: string;
+
+    /*@ new () => { BB<M> | true } */
     constructor() {
       super();
       this.l = "L";

--- a/tests/neg/classes/ctor-05-2.ts
+++ b/tests/neg/classes/ctor-05-2.ts
@@ -8,6 +8,8 @@ module K {
 
         /*@ y0 : [Immutable] { string | v = "" } */
         public y0 = "";
+
+        /*@ new () => { A<M> | true } */
         constructor() {}
       }
 
@@ -21,6 +23,7 @@ module Mod {
     /*@ k : [Immutable] { string | v = "K" } */
     public k = "K";  
 
+    /*@ new () => { AA<M> | true } */
     constructor() {
       super();
     }
@@ -34,6 +37,7 @@ module N {
     /*@ k : [Immutable] { string | v = "KK" } */
     public k: string;
 
+    /*@ new () => BB<M> */
     constructor() {
       super();
       this.l = "L";

--- a/tests/neg/classes/ctor-06.ts
+++ b/tests/neg/classes/ctor-06.ts
@@ -4,6 +4,7 @@ class AA {
   /*@ a : [Immutable] { string | v = "OLD" } */
   public a = "OLD"; 
 
+  /*@ new () => { AA<M> | true } */
   constructor () {}
 }
 
@@ -12,7 +13,7 @@ class BB extends AA {
   
   public b = 0;
     
-  /*@ new () => BB<M> */
+  /*@ new () => { BB<M> | true } */
   constructor() {
     super();
     this.a = "NEW";

--- a/tests/neg/classes/ctor-08.ts
+++ b/tests/neg/classes/ctor-08.ts
@@ -1,0 +1,22 @@
+
+class AA { 
+
+  /*@ x : [Mutable] number */
+  public x = 0; 
+
+
+  // Refinement CANNOT refer to mutable fields 
+  
+  /*@ y : [Immutable] { number | v = x } */
+  public y = 0;
+    
+  constructor() { }
+    
+}
+
+var aa = new AA();
+
+aa.x = 1;
+
+assert(aa.x === aa.y);
+

--- a/tests/neg/classes/init-00.ts
+++ b/tests/neg/classes/init-00.ts
@@ -5,7 +5,7 @@ class PosPoint {
     /*@ y: [#Mutable]{ number | v >= 0 } */
     y: number;
 
-    /*@ new (a: number, b: number) => void */
+    /*@ new (a: number, b: number) => { PosPoint<M> | true } */
     constructor(a: number, b: number) {
         if (a > 0 && b > 0) { this.x = a; this.y = b; }
         else                { this.x = 0; }

--- a/tests/neg/classes/init-01.ts
+++ b/tests/neg/classes/init-01.ts
@@ -5,7 +5,7 @@ class PosPoint {
     /*@ y: [#Mutable]{ number | v >= 0 } */
     y: number;
 
-    /*@ new (a: number, b: number) => void */
+    /*@ new (a: number, b: number) => { PosPoint<M> | true } */
     constructor(a: number, b: number) {
         if (a > 0 && b > 0) { this.x = a; this.y = b; }
         else                { this.x = 0; this.y = -1; }

--- a/tests/pos/classes/class-00.ts
+++ b/tests/pos/classes/class-00.ts
@@ -6,7 +6,7 @@ class BankAccount {
 	/*@  g : { string | v = "a" } */
 	public g : string = "a";
   
-	/*@ new (x: { number | v > 0 } ) => void */
+  /*@ new (x: { number | v > 0 } ) => BankAccount<M> */
 	constructor(x : number) {
 		assert( x > 0 );
 		// assert(this.g === "a");

--- a/tests/pos/classes/class-03.ts
+++ b/tests/pos/classes/class-03.ts
@@ -2,10 +2,10 @@
 /*@ class Foo<M,A> */
 class Foo<A> { 
 
-	/*@ f : [#Mutable] A */ 
+	/*@ f : [Mutable] A */ 
 	public f;
   
-	/*@ new(x:A) => void */
+  /*@ new(x:A) => Foo<M,A> */
 	constructor(x) {
 		this.f = x;
 	}

--- a/tests/pos/classes/class-04.ts
+++ b/tests/pos/classes/class-04.ts
@@ -19,7 +19,7 @@ class CP extends P implements ICPoint {
   /*@ c : { string | v = "red" } */
   public c: string;
    
-  /*@ new (c: { string | v = "red" }) => void */
+  /*@ new (c: { string | v = "red" }) => CP<M> */
   constructor (c: string) { super(1); this.c = c; }
 }
 

--- a/tests/pos/classes/class-06.ts
+++ b/tests/pos/classes/class-06.ts
@@ -1,7 +1,7 @@
 
 class A<T> {
 
-  /*@ new(x:T) => void */
+  /*@ new(x:T) => A<M,T> */
   constructor (x:T) {
   
   }
@@ -14,7 +14,7 @@ class A<T> {
 
 }
 
-/*@ a :: #A[#Mutable,number] */
+/*@ a :: A<Mutable,number> */
 var a : A<number> = new A(1);
 
 assert(a.n > 0);

--- a/tests/pos/classes/class-10.ts
+++ b/tests/pos/classes/class-10.ts
@@ -7,7 +7,7 @@ function foo(x: Node) {
 }
 
 class Node {
-  /*@ new () => void */
+  /*@ new () => Node<M> */
   constructor() { }
 
   /*@ field : [Mutable] number */

--- a/tests/pos/classes/ctor-07.ts
+++ b/tests/pos/classes/ctor-07.ts
@@ -17,4 +17,4 @@ class Foo {
 
 var z = new Foo(5)
 
-z.bar(6);
+z.bar(5);

--- a/tests/pos/classes/func-field-ctor.ts
+++ b/tests/pos/classes/func-field-ctor.ts
@@ -2,7 +2,7 @@
 class Foo {
 
   public bar: () => number;
-  /*@ new () => { void | true } */
+  /*@ new () => { Foo<M> | true } */
   constructor() {
     this.bar = function() 
     /*@ <anonymous> () => number */

--- a/tests/pos/classes/glob-in-method.ts
+++ b/tests/pos/classes/glob-in-method.ts
@@ -1,5 +1,5 @@
 class Blah {
-  /*@ new () => void */
+  /*@ new () => Blah<M> */
   constructor() { }
 
   public state = 3;

--- a/tests/pos/classes/implements-00.ts
+++ b/tests/pos/classes/implements-00.ts
@@ -3,7 +3,7 @@
 interface Foo {}
 
 class FooImpl implements Foo {
-  /*@ new() => {void | true} */
+/*@ new() => { Foo<M> | true} */
   constructor() { }
 }
 

--- a/tests/pos/classes/implements-01.ts
+++ b/tests/pos/classes/implements-01.ts
@@ -9,7 +9,7 @@ class FooImpl implements Foo, Bar {
   x = 1;
   y = 2;
 
-  /*@ new() => {void | true} */
+  /*@ new() => { FooImpl<M> | true} */
   constructor() { }
 }
 

--- a/tests/pos/classes/init-00.ts
+++ b/tests/pos/classes/init-00.ts
@@ -5,7 +5,7 @@ class PosPoint {
     /*@ y: [#Mutable]{ number | v >= 0 } */
     y: number;
 
-    /*@ new (a: number, b: number) => void */
+    /*@ new (a: number, b: number) => PosPoint<M> */
     constructor(a: number, b: number) {
         this.x = a - a; 
         this.y = b - b;

--- a/tests/pos/classes/init-01.ts
+++ b/tests/pos/classes/init-01.ts
@@ -5,7 +5,7 @@ class PosPoint {
     /*@ y: [#Mutable]{ number | v >= 0 } */
     y: number;
 
-    /*@ new (a: number, b: number) => void */
+    /*@ new (a: number, b: number) => PosPoint<M> */
     constructor(a: number, b: number) {
         if (a > 0 && b > 0) { this.x = a; this.y = b; }
         else                { this.x = 0; this.y = 0; }

--- a/tests/pos/classes/init-02.ts
+++ b/tests/pos/classes/init-02.ts
@@ -1,7 +1,7 @@
 
 class Foo {
   public f: number;
-  /*@ new (id: number) => { void | true } */
+  /*@ new (id: number) => { Foo<M> | true } */
   constructor(a: number) { this.f = a; }
 }
 

--- a/tests/pos/classes/init-03.ts
+++ b/tests/pos/classes/init-03.ts
@@ -4,7 +4,7 @@ class Foo {
   /*@ f : { number | v = 4 } */
   public f: number;
 
-  /*@ new (id: { number | v = 4 }) => void */
+  /*@ new (id: { number | v = 4 }) => Foo<M> */
   constructor(a: number) { this.f = a; }
 
 }

--- a/tests/pos/classes/method-mut.ts
+++ b/tests/pos/classes/method-mut.ts
@@ -1,7 +1,7 @@
 class Foo {
   public x:number;
 
-  /*@ new () => void */
+  /*@ new () => Foo<M> */
   constructor() { this.x = 3; }
 
   /*@ bar: (this: Foo<Mutable>): { void | true } */

--- a/tests/pos/misc/formerly-crashing.ts
+++ b/tests/pos/misc/formerly-crashing.ts
@@ -15,6 +15,5 @@ function foo(x, y) {
 }
 
 class Node {
-  /*@ new () => void */
   constructor() { }
 }

--- a/tests/pos/misc/safe-meth-call.ts
+++ b/tests/pos/misc/safe-meth-call.ts
@@ -1,5 +1,5 @@
 class Tree {
-  /*@ new() => {void | true} */
+/*@ new() => {Tree<M> | true} */
   constructor() {}
 
   /*@ root : TreeNode<Immutable> + null */

--- a/tests/pos/simple/ref-in-constructor.ts
+++ b/tests/pos/simple/ref-in-constructor.ts
@@ -1,4 +1,4 @@
 class Foo {
-    /*@ new (x: number, y: {number | v < x}) => void */
+    /*@ new (x: number, y: {number | v < x}) => Foo<M> */
     constructor(x, y) { }
 }

--- a/tests/todo/missing-qualif.ts
+++ b/tests/todo/missing-qualif.ts
@@ -1,5 +1,5 @@
 
-/*@ qualif Add(v: number, n: number, m: number): v = m + n */
+/*@ qualif Add(v: number, n: number, m: number): v < m + n */
 
 /*@ lin_solve :: () => void */
 function lin_solve() {


### PR DESCRIPTION
Addresses #118 

Adds support for invariants like the following:
```
class Foo {
  /*@ a : [Immutable] number */
  a;

  /*@ new (x: number) => { v: Foo<M> | offset(v,"a") = x } */
  constructor(x) { this.a = x }
  ...
}
```

See: https://github.com/UCSD-PL/RefScript/blob/ctor-invariants/tests/pos/classes/ctor-07.ts

Whenever possible `offset(v,"a") = x` is also strengthened by `y.a = x` in the type's refinement, where y is the object that enters the environment.

The reason we use a separate mechanism here (`offset`) is that qualified symbols (`x.a`) are immune to regular substitution and require special handling.