### PR TITLE
Refa / RConc

### DIFF
--- a/src/Language/Nano/Liquid/CGMonad.hs
+++ b/src/Language/Nano/Liquid/CGMonad.hs
@@ -1,7 +1,4 @@
 {-# LANGUAGE TypeSynonymInstances      #-}
-{-# LANGUAGE NoMonomorphismRestriction #-}
-{-# LANGUAGE FlexibleInstances         #-}
-{-# LANGUAGE ViewPatterns              #-}
 {-# LANGUAGE LambdaCase                #-}
 {-# LANGUAGE ConstraintKinds           #-}
 {-# LANGUAGE FlexibleContexts          #-}
@@ -14,7 +11,7 @@
 -- | Operations pertaining to Constraint Generation
 
 module Language.Nano.Liquid.CGMonad (
-    
+
   -- * Constraint Generation Monad
     CGM
 
@@ -22,12 +19,12 @@ module Language.Nano.Liquid.CGMonad (
   , CGInfo (..)
 
   -- * Execute Action and Get FInfo
-  , getCGInfo 
+  , getCGInfo
 
   -- * Throw Errors
-  , cgError      
+  , cgError
 
-  -- * Fresh Templates for Unknown Refinement Types 
+  -- * Fresh Templates for Unknown Refinement Types
   , freshTyFun, freshenType, freshTyInst, freshTyPhis, freshTyPhis'
   , freshTyObj, freshenCGEnvM
 
@@ -47,21 +44,21 @@ module Language.Nano.Liquid.CGMonad (
 
   -- * Add Subtyping Constraints
   , subType, wellFormed -- , safeExtends
-  
+
   -- * Add Type Annotations
   , addAnnot
 
   -- * Function Types
-  , cgFunTys, subNoCapture 
+  , cgFunTys, subNoCapture
 
   -- * Zip type wrapper
   , zipTypeUpM, zipTypeDownM
 
-  , checkSyms 
+  , checkSyms
 
   ) where
 
-import           Control.Applicative 
+import           Control.Applicative
 import           Control.Exception (throw)
 import           Control.Monad
 import           Control.Monad.State
@@ -105,7 +102,7 @@ import           Language.Nano.Syntax.PrettyPrint
 -------------------------------------------------------------------------------
 
 data CGInfo = CGI { cgi_finfo :: F.FInfo Cinfo
-                  , cgi_annot :: S.UAnnInfo RefType  
+                  , cgi_annot :: S.UAnnInfo RefType
                   }
 
 -- Dump the refinement subtyping constraints
@@ -120,23 +117,23 @@ instance PP (F.SubC c) where
 getCGInfo :: Config -> NanoRefType -> CGM a -> CGInfo
 -------------------------------------------------------------------------------
 getCGInfo cfg pgm = cgStateCInfo pgm . execute cfg pgm . (>> fixCWs)
-  where 
+  where
     fixCWs       = (,) <$> fixCs <*> fixWs
     fixCs        = get >>= concatMapM splitC . cs
     fixWs        = get >>= concatMapM splitW . ws
 
 execute :: Config -> NanoRefType -> CGM a -> (a, CGState)
 execute cfg pgm act
-  = case runState (runExceptT act) $ initState cfg pgm of 
+  = case runState (runExceptT act) $ initState cfg pgm of
       (Left err, _) -> throw err
-      (Right x, st) -> (x, st)  
+      (Right x, st) -> (x, st)
 
 
 -------------------------------------------------------------------------------
 initState       :: Config -> Nano AnnTypeR F.Reft -> CGState
 -------------------------------------------------------------------------------
 initState c p   = CGS F.emptyBindEnv [] [] 0 mempty invs c (max_id p)
-  where 
+  where
     invs        = HM.fromList [(tc, t) | t@(Loc _ (TApp tc _ _)) <- invts p]
 
 
@@ -144,8 +141,8 @@ initState c p   = CGS F.emptyBindEnv [] [] 0 mempty invs c (max_id p)
 cgStateCInfo :: NanoRefType -> (([F.SubC Cinfo], [F.WfC Cinfo]), CGState) -> CGInfo
 -------------------------------------------------------------------------------
 cgStateCInfo pgm ((fcs, fws), cg) = CGI (patchSymLits fi) (cg_ann cg)
-  where 
-    fi   = F.FI { F.cm    = HM.fromList $ F.addIds fcs  
+  where
+    fi   = F.FI { F.cm    = HM.fromList $ F.addIds fcs
                 , F.ws    = fws
                 , F.bs    = binds cg
                 , F.gs    = measureEnv pgm
@@ -162,42 +159,42 @@ patchSymLits fi = fi { F.lits = F.symConstLits fi ++ F.lits fi }
 ---------------------------------------------------------------------------------------
 measureEnv   ::  Nano a F.Reft -> F.SEnv F.SortedReft
 ---------------------------------------------------------------------------------------
-measureEnv   = fmap rTypeSortedReft . E.envSEnv . consts 
+measureEnv   = fmap rTypeSortedReft . E.envSEnv . consts
 
 ---------------------------------------------------------------------------------------
--- | Constraint Generation Monad 
+-- | Constraint Generation Monad
 ---------------------------------------------------------------------------------------
 
-data CGState = CGS { 
-  -- 
+data CGState = CGS {
+  --
   -- ^ global list of fixpoint binders
   --
     binds       :: F.BindEnv
-  -- 
+  --
   -- ^ subtyping constraints
   --
   , cs          :: ![SubC]
-  -- 
+  --
   -- ^ well-formedness constraints
   --
-  , ws          :: ![WfC]               
-  -- 
+  , ws          :: ![WfC]
+  --
   -- ^ freshness counter
   --
-  , cg_cnt      :: !Integer             
-  -- 
+  , cg_cnt      :: !Integer
+  --
   -- ^ recorded annotations
   --
-  , cg_ann      :: S.UAnnInfo RefType   
-  -- 
+  , cg_ann      :: S.UAnnInfo RefType
+  --
   -- ^ type constructor invariants
   --
   , invs        :: TConInv
-  -- 
+  --
   -- ^ configuration options
   --
-  , cg_opts     :: Config               
-  -- 
+  , cg_opts     :: Config
+  --
   -- ^ AST Counter
   --
   , cg_ast_cnt  :: NodeId
@@ -207,10 +204,10 @@ data CGState = CGS {
 type CGM     = ExceptT Error (State CGState)
 
 type TConInv = HM.HashMap TCon (Located RefType)
- 
+
 
 ---------------------------------------------------------------------------------------
-cgError     :: Error -> CGM b 
+cgError     :: Error -> CGM b
 ---------------------------------------------------------------------------------------
 cgError err = throwE $ catMessage err "CG-ERROR\n"
 
@@ -226,12 +223,12 @@ envPushContext c g = g {cge_ctx = pushContext c (cge_ctx g)}
 ---------------------------------------------------------------------------------------
 envGetContextCast :: CGEnv -> AnnTypeR -> Cast F.Reft
 ---------------------------------------------------------------------------------------
-envGetContextCast g a 
+envGetContextCast g a
   = case [c | TCast cx c <- ann_fact a, cx == cge_ctx g] of
       [ ] -> CNo
       [c] -> c
-      cs  -> case L.find isDeadCast cs of 
-               Just dc -> dc 
+      cs  -> case L.find isDeadCast cs of
+               Just dc -> dc
                Nothing -> die $ errorMultipleCasts (srcPos a) cs
   where
     isDeadCast CDead{} = True
@@ -245,44 +242,44 @@ envGetContextTypArgs :: Int -> CGEnv -> AnnTypeR -> [TVar] -> [RefType]
 -- NOTE: If we do not need to instantiate any type parameter (i.e. length αs ==
 -- 0), DO NOT attempt to compare that with the TypInst that might hide within
 -- the expression, cause those type instantiations might serve anothor reason
--- (i.e. might be there for a separate instantiation).  
+-- (i.e. might be there for a separate instantiation).
 envGetContextTypArgs _ _ _ [] = []
 envGetContextTypArgs n g a αs
   = case tys of
-      [i] | length i == length αs -> i 
+      [i] | length i == length αs -> i
       _                           -> die $ bugMissingTypeArgs $ srcPos a
   where
     tys = [i | TypInst m ξ' i <- ann_fact a
              , ξ' == cge_ctx g
-             , n == m ] 
+             , n == m ]
 
 
 ---------------------------------------------------------------------------------------
-envAddFresh :: IsLocated l 
+envAddFresh :: IsLocated l
             => String
-            -> l 
-            -> (RefType, Assignability, Initialization) 
-            -> CGEnv 
-            -> CGM (Id AnnTypeR, CGEnv) 
+            -> l
+            -> (RefType, Assignability, Initialization)
+            -> CGEnv
+            -> CGM (Id AnnTypeR, CGEnv)
 ---------------------------------------------------------------------------------------
-envAddFresh msg l (t,a,i) g 
+envAddFresh msg l (t,a,i) g
   = do x  <- freshId l
        g' <- envAdds ("envAddFresh: " ++ msg) [(x, EE a i t)] g
        addAnnot l x t
        return (x, g')
-   
+
 freshId a = Id <$> freshenAnn a <*> fresh
 
 freshenAnn :: IsLocated l => l -> CGM AnnTypeR
 freshenAnn l
-  = do n     <- cg_ast_cnt <$> get 
+  = do n     <- cg_ast_cnt <$> get
        modify $ \st -> st {cg_ast_cnt = 1 + n}
        return $ Ann n (srcPos l) []
 
 ---------------------------------------------------------------------------------------
 envAdds :: EnvKey x => String -> [(x, CGEnvEntry)] -> CGEnv -> CGM CGEnv
 ---------------------------------------------------------------------------------------
-envAdds msg xts g = foldM (envAddGroup msg ks) g es 
+envAdds msg xts g = foldM (envAddGroup msg ks) g es
   where
     es = objFields g <$> xts
     ks = F.symbol . fst <$> xts
@@ -315,31 +312,31 @@ envAddGroup msg ks g (x,xts) = do
 ---------------------------------------------------------------------------------------
 checkSyms :: EnvKey a => String -> CGEnv -> [a] -> a -> RefType -> CGM ()
 ---------------------------------------------------------------------------------------
-checkSyms m g ok x t = mapM_ cgError errs 
+checkSyms m g ok x t = mapM_ cgError errs
   where
     errs             = efoldRType h f F.emptySEnv [] t
-    
+
     h _              = ()
     f γ t' s         = s ++ catMaybes (chk γ t' <$> F.syms (noKVars $ rTypeReft t'))
 
-    chk γ t' s       | s `L.elem` biReserved              
+    chk γ t' s       | s `L.elem` biReserved
                      = Just $ unimplementedReservedSyms l
-                     | s == x_sym                         
+                     | s == x_sym
                      = Nothing
-                     | s == rTypeValueVar t'              
-                     = Nothing  
+                     | s == rTypeValueVar t'
+                     = Nothing
                      | s `L.elem` ok_syms
-                     = Nothing 
-                     | s `F.memberSEnv` γ 
                      = Nothing
-                     | s `F.memberSEnv` cge_consts g      
+                     | s `F.memberSEnv` γ
                      = Nothing
-                     | s `L.elem` biExtra                 
+                     | s `F.memberSEnv` cge_consts g
                      = Nothing
-                     | Just (EE a _ _) <- envLikeFindTy' s g 
+                     | s `L.elem` biExtra
+                     = Nothing
+                     | Just (EE a _ _) <- envLikeFindTy' s g
                      = if a `L.elem` validAsgn then Nothing
-                                               else Just $ errorAsgnInRef l x t a 
-                     | otherwise                          
+                                               else Just $ errorAsgnInRef l x t a
+                     | otherwise
                      = Just $ errorUnboundSyms l (F.symbol x) t s m
 
     l                = srcPos x
@@ -348,13 +345,13 @@ checkSyms m g ok x t = mapM_ cgError errs
     biExtra          = F.symbol <$> ["bvor", "bvand", "builtin_BINumArgs", "offset", "this"]
     x_sym            = F.symbol x
     ok_syms          = F.symbol <$> ok
-    validAsgn        = [ReadOnly,ImportDecl,WriteLocal] 
+    validAsgn        = [ReadOnly,ImportDecl,WriteLocal]
 
 -- | Bindings for IMMUTABLE fields
 ---------------------------------------------------------------------------------------
 objFields :: EnvKey x => CGEnv -> (x, CGEnvEntry) -> (F.Symbol, [(F.Symbol,CGEnvEntry)])
 ---------------------------------------------------------------------------------------
-objFields g (x, e@(EE a _ t)) 
+objFields g (x, e@(EE a _ t))
               | a `elem` [WriteGlobal,ReturnVar] = (x_sym, [(x_sym,e)])
               | otherwise = (x_sym, (x_sym,e):xts)
   where
@@ -375,8 +372,8 @@ objFields g (x, e@(EE a _ t))
 addFixpointBind :: EnvKey x => x -> CGEnvEntry -> CGM (Maybe F.BindId)
 ---------------------------------------------------------------------------------------
 -- No binding for globals or RetVal: shouldn't appear in refinements
-addFixpointBind _ (EE WriteGlobal _ _) = return Nothing    
-addFixpointBind _ (EE ReturnVar _ _) = return Nothing 
+addFixpointBind _ (EE WriteGlobal _ _) = return Nothing
+addFixpointBind _ (EE ReturnVar _ _) = return Nothing
 addFixpointBind x (EE _ _ t)
   = do  bs           <- binds <$> get
         let (i, bs')  = F.insertBindEnv (F.symbol x) r bs
@@ -389,40 +386,39 @@ addFixpointBind x (EE _ _ t)
 ---------------------------------------------------------------------------------------
 addInvariant :: CGEnv -> RefType -> CGM RefType
 ---------------------------------------------------------------------------------------
-addInvariant g t             
+addInvariant g t
   = do  extraInvariants <- extraInvs <$> cg_opts <$> get
         if extraInvariants then (hasProp . hierarchy . truthy . typeof t . invs) <$> get
                            else (          hierarchy . truthy . typeof t . invs) <$> get
   where
-    -- | typeof 
+    -- | typeof
     typeof t@(TApp tc _ o)  i = maybe t (strengthenOp t o . rTypeReft . val) $ HM.lookup tc i
-    typeof t@(TRef _ _ _) _   = t `nubstrengthen` F.Reft ((vv t,) [ F.RConc $ typeofExpr $ F.symbol "object" ])
-    typeof t@(TCons _ _ _) _  = t `nubstrengthen` F.Reft ((vv t,) [ F.RConc $ typeofExpr $ F.symbol "object" ])
+    typeof t@(TRef _ _ _) _   = t `nubstrengthen` F.reft (vv t) (typeofExpr $ F.symbol "object")
+    typeof t@(TCons _ _ _) _  = t `nubstrengthen` F.reft (vv t) (typeofExpr $ F.symbol "object")
     typeof   (TFun a b c _) _ = TFun a b c typeofReft
     typeof t                _ = t
     -- | Truthy
     truthy t                  | isTObj t
-                              = t `nubstrengthen` F.Reft ((vv t,) [ F.RConc $ F.eProp $ vv t ])
+                              = t `nubstrengthen` F.reft (vv t) (F.eProp $ vv t)
                               | otherwise          = t
 
-    strengthenOp t o r        | L.elem r (ofRef o) = t
-    strengthenOp t _ r        | otherwise          = t `nubstrengthen` r
-    typeofReft                = F.Reft $ (vv t,) [ F.RConc $ typeofExpr $ F.symbol "function"
-                                                 , F.RConc $ F.eProp    $ vv t                ]
-    typeofExpr s              = F.PAtom F.Eq (F.EApp (F.dummyLoc (F.symbol "ttag")) [F.eVar $ vv t]) 
+    strengthenOp t o r        | r `L.elem` ofRef o = t
+                              | otherwise          = t `nubstrengthen` r
+    typeofReft                = F.reft  (vv t) $ F.pAnd [ typeofExpr $ F.symbol "function"
+                                                        , F.eProp    $ vv t                ]
+    typeofExpr s              = F.PAtom F.Eq (F.EApp (F.dummyLoc (F.symbol "ttag")) [F.eVar $ vv t])
                                              (F.expr $ F.symbolText s)
 
     ofRef (F.Reft (s, as))    = (F.Reft . (s,) . single) <$> as
 
     -- | { f: T } --> hasProperty("f", v)
-    hasProp t                   = t `nubstrengthen` keyReft (boundKeys g t) 
-
-    keyReft                   = F.Reft . (vv t,) . (F.RConc . F.PBexp . hasPropExpr <$>) 
-    hasPropExpr s             = F.EApp (F.dummyLoc (F.symbol "hasProperty")) 
+    hasProp t                   = t `nubstrengthen` keyReft (boundKeys g t)
+    keyReft                   = F.reft (vv t) . (F.PBexp . hasPropExpr <$>)
+    hasPropExpr s             = F.EApp (F.dummyLoc (F.symbol "hasProperty"))
                                 [F.expr (F.symbolText s), F.eVar $ vv t]
 
     -- | extends class / interface
-    hierarchy t@(TRef c _ _)  | isClassType g t 
+    hierarchy t@(TRef c _ _)  | isClassType g t
                               = t `nubstrengthen` rExtClass t (name <$> classAncestors g c)
                               | otherwise
                               = t `nubstrengthen` rExtIface t (name <$> interfaceAncestors g c)
@@ -430,11 +426,10 @@ addInvariant g t
 
     name (QN AK_ _ _ s)       = s
 
-    rExtClass t cs            = F.Reft (vv t, refa t "extends_class"     <$> cs)
-    rExtIface t cs            = F.Reft (vv t, refa t "extends_interface" <$> cs)
+    rExtClass t cs            = F.reft (vv t) (F.pAnd $ refa t "extends_class"     <$> cs)
+    rExtIface t cs            = F.reft (vv t) (F.pAnd $ refa t "extends_interface" <$> cs)
 
-    refa t s c                = F.RConc $ F.PBexp $ F.EApp (sym s) 
-                              $ [ F.expr $ rTypeValueVar t, F.expr $ F.symbolText c ]
+    refa t s c                = F.PBexp $ F.EApp (sym s) [ F.expr $ rTypeValueVar t, F.expr $ F.symbolText c]
     vv                        = rTypeValueVar
     sym s                     = F.dummyLoc $ F.symbol s
 
@@ -442,12 +437,12 @@ addInvariant g t
 ----------------------------------------------------------------------------------------
 nubstrengthen                   :: RefType -> F.Reft -> RefType
 ----------------------------------------------------------------------------------------
-nubstrengthen (TApp c ts r) r'  = TApp c ts  $ r' `meetReft` r 
-nubstrengthen (TRef c ts r) r'  = TRef c ts  $ r' `meetReft` r 
-nubstrengthen (TCons ts m r) r' = TCons ts m $ r' `meetReft` r 
-nubstrengthen (TVar α r)    r'  = TVar α     $ r' `meetReft` r 
+nubstrengthen (TApp c ts r) r'  = TApp c ts  $ r' `meetReft` r
+nubstrengthen (TRef c ts r) r'  = TRef c ts  $ r' `meetReft` r
+nubstrengthen (TCons ts m r) r' = TCons ts m $ r' `meetReft` r
+nubstrengthen (TVar α r)    r'  = TVar α     $ r' `meetReft` r
 nubstrengthen (TFun a b c r) r' = TFun a b c $ r' `meetReft` r
-nubstrengthen t _               = t                         
+nubstrengthen t _               = t
 
 meetReft (F.Reft (v, ras)) (F.Reft (v', ras'))
   | v == v'            = F.Reft (v , L.nubBy cmp $ ras  ++ ras')
@@ -460,29 +455,29 @@ meetReft (F.Reft (v, ras)) (F.Reft (v', ras'))
 
 
 ---------------------------------------------------------------------------------------
-addAnnot       :: (IsLocated l, F.Symbolic x) => l -> x -> RefType -> CGM () 
+addAnnot       :: (IsLocated l, F.Symbolic x) => l -> x -> RefType -> CGM ()
 ---------------------------------------------------------------------------------------
 addAnnot l x t = modify $ \st -> st {cg_ann = S.addAnnot (srcPos l) x t (cg_ann st)}
 
 ---------------------------------------------------------------------------------------
-envAddReturn        :: (IsLocated f)  => f -> RefType -> CGEnv -> CGM CGEnv 
+envAddReturn        :: (IsLocated f)  => f -> RefType -> CGEnv -> CGM CGEnv
 ---------------------------------------------------------------------------------------
-envAddReturn f t g  = return $ g { cge_names = E.envAddReturn f e $ cge_names g } 
+envAddReturn f t g  = return $ g { cge_names = E.envAddReturn f e $ cge_names g }
   where
     e   = EE ReturnVar Initialized t
 
 ---------------------------------------------------------------------------------------
-envAddGuard       :: (F.Symbolic x, IsLocated x) => x -> Bool -> CGEnv -> CGEnv  
+envAddGuard       :: (F.Symbolic x, IsLocated x) => x -> Bool -> CGEnv -> CGEnv
 ---------------------------------------------------------------------------------------
 envAddGuard x b g = g { cge_guards = guard b x : cge_guards g }
-  where 
-    guard True    = F.eProp 
+  where
+    guard True    = F.eProp
     guard False   = F.PNot . F.eProp
 
 ---------------------------------------------------------------------------------------
-envPopGuard       :: CGEnv -> CGEnv  
+envPopGuard       :: CGEnv -> CGEnv
 ---------------------------------------------------------------------------------------
-envPopGuard g = g { cge_guards = grdPop $ cge_guards g } 
+envPopGuard g = g { cge_guards = grdPop $ cge_guards g }
   where
     grdPop (_:xs) = xs
     grdPop []     = []
@@ -496,7 +491,7 @@ instance F.Expression TVar where
 
 
 -- | A helper that returns the @RefType@ of variable @x@. Interstring cases:
---   
+--
 --   * Global variables (that can still be assigned) should not be strengthened
 --     with single
 --
@@ -505,7 +500,7 @@ instance F.Expression TVar where
 --   * Local (non-assignable) variables (strengthened with singleton for base-types)
 --
 ---------------------------------------------------------------------------------------
-envFindTy :: (EnvKey x, F.Expression x) => x -> CGEnv -> Maybe RefType 
+envFindTy :: (EnvKey x, F.Expression x) => x -> CGEnv -> Maybe RefType
 ---------------------------------------------------------------------------------------
 envFindTy x g = ee_type <$> envFindTyWithAsgn x g
 
@@ -529,19 +524,19 @@ envFindTyWithAsgn x = (singleton <$>) . envFindTy_ x
 ---------------------------------------------------------------------------------------
 envFindTy_ :: EnvKey x => x -> CGEnv -> Maybe CGEnvEntry
 ---------------------------------------------------------------------------------------
-envFindTy_ x g 
+envFindTy_ x g
   | Just t  <- E.envFindTy x $ cge_names g = Just t
   | Just g' <- cge_parent g                = envFindTy_ x g'
   |otherwise                               = Nothing
 
 ---------------------------------------------------------------------------------------
-safeEnvFindTy :: (EnvKey x, F.Expression x) => x -> CGEnv -> CGM RefType 
+safeEnvFindTy :: (EnvKey x, F.Expression x) => x -> CGEnv -> CGM RefType
 ---------------------------------------------------------------------------------------
 safeEnvFindTy x g | Just t <- envFindTy x g = return t
                   | otherwise = cgError $ bugEnvFindTy (srcPos x) x
 
 ---------------------------------------------------------------------------------------
-safeEnvFindTyNoSngl :: EnvKey x => x -> CGEnv -> CGM RefType 
+safeEnvFindTyNoSngl :: EnvKey x => x -> CGEnv -> CGM RefType
 ---------------------------------------------------------------------------------------
 safeEnvFindTyNoSngl x g | Just t <- envFindTyNoSngl x g = return t
                         | otherwise = cgError $ bugEnvFindTy (srcPos x) x
@@ -553,7 +548,7 @@ safeEnvFindTyWithAsgn x g | Just t <- envFindTyWithAsgn x g = return t
                           | otherwise = cgError $ bugEnvFindTy (srcPos x) x
 
 ---------------------------------------------------------------------------------------
-envFindReturn :: CGEnv -> RefType 
+envFindReturn :: CGEnv -> RefType
 ---------------------------------------------------------------------------------------
 envFindReturn = ee_type . E.envFindReturn . cge_names
 
@@ -564,7 +559,7 @@ envFindReturn = ee_type . E.envFindReturn . cge_names
 
 -- | Instantiate Fresh Type (at Function-site)
 ---------------------------------------------------------------------------------------
-freshTyFun :: (IsLocated l) => CGEnv -> l -> RefType -> CGM RefType 
+freshTyFun :: (IsLocated l) => CGEnv -> l -> RefType -> CGM RefType
 ---------------------------------------------------------------------------------------
 freshTyFun g l t
   | not (isTFun t)     = return t
@@ -572,12 +567,12 @@ freshTyFun g l t
   | otherwise          = return t
 
 
-freshenType WriteGlobal g l t 
+freshenType WriteGlobal g l t
   | isTrivialRefType t = freshTy "freshenType-WG" (toType t) >>= wellFormed l g
   | otherwise          = return t
 
-freshenType _ g l t 
-  | not (isTFun t)     = return t   
+freshenType _ g l t
+  | not (isTFun t)     = return t
   | isTrivialRefType t = freshTy "freshenType-RO" (toType t) >>= wellFormed l g
   | otherwise          = return t
 
@@ -588,20 +583,20 @@ freshTyInst l g αs τs tbody
        _     <- mapM (wellFormed l g) ts
        return $ apply (fromList $ zip αs ts) tbody
 
--- | Instantiate Fresh Type (at Phi-site) 
+-- | Instantiate Fresh Type (at Phi-site)
 ---------------------------------------------------------------------------------------
-freshTyPhis :: AnnTypeR -> CGEnv -> [Id AnnTypeR] -> [Type] -> CGM (CGEnv, [RefType])  
+freshTyPhis :: AnnTypeR -> CGEnv -> [Id AnnTypeR] -> [Type] -> CGM (CGEnv, [RefType])
 ---------------------------------------------------------------------------------------
-freshTyPhis l g xs τs 
+freshTyPhis l g xs τs
   = do ts <- mapM (freshTy "freshTyPhis") τs
        g' <- envAdds "freshTyPhis" (zip xs (EE WriteLocal Initialized <$> ts)) g
        _  <- mapM (wellFormed l g') ts
        return (g', ts)
 
 
--- | Instantiate Fresh Type (at Phi-site) 
+-- | Instantiate Fresh Type (at Phi-site)
 ---------------------------------------------------------------------------------------
-freshTyPhis' :: AnnTypeR -> CGEnv -> [Id AnnTypeR] -> [EnvEntry ()] -> CGM (CGEnv, [RefType])  
+freshTyPhis' :: AnnTypeR -> CGEnv -> [Id AnnTypeR] -> [EnvEntry ()] -> CGM (CGEnv, [RefType])
 ---------------------------------------------------------------------------------------
 freshTyPhis' l g xs es
   = do ts' <- mapM (freshTy "freshTyPhis") ts
@@ -614,18 +609,18 @@ freshTyPhis' l g xs es
 
 -- | Fresh Object Type
 ---------------------------------------------------------------------------------------
-freshTyObj :: (IsLocated l) => l -> CGEnv -> RefType -> CGM RefType 
+freshTyObj :: (IsLocated l) => l -> CGEnv -> RefType -> CGM RefType
 ---------------------------------------------------------------------------------------
-freshTyObj l g t = freshTy "freshTyArr" t >>= wellFormed l g 
+freshTyObj l g t = freshTy "freshTyArr" t >>= wellFormed l g
 
 
 ---------------------------------------------------------------------------------------
 freshenCGEnvM :: CGEnv -> CGM CGEnv
 ---------------------------------------------------------------------------------------
-freshenCGEnvM g  
+freshenCGEnvM g
   = do  names   <- E.envFromList  <$> mapM (go g) (E.envToList  $ cge_names g)
         modules <- E.qenvFromList <$> mapM (freshenModuleDefM g) (E.qenvToList $ cge_mod g)
-        return $ g { cge_names = names, cge_mod = modules } 
+        return $ g { cge_names = names, cge_mod = modules }
   where
     go _ (x, EE a i v@TVar{}) = return (x, EE a i v)
     go g (x, EE ReadOnly i t) = (x,) . EE ReadOnly i <$> freshenType ReadOnly g (srcPos x) t
@@ -638,12 +633,12 @@ freshenModuleDefM g (a, m)
   where
     f (x, (v,w,t,i)) =
       case w of
-        ReadOnly   -> do  ft    <- freshenType ReadOnly g x t 
+        ReadOnly   -> do  ft    <- freshenType ReadOnly g x t
                           return   (x, (v, w, ft,i))
         _          -> return (x,(v,w,t,i))
 
     -- KVar class definitions only
-    h (x, t) | t_class t == ClassKind 
+    h (x, t) | t_class t == ClassKind
              = do es <- M.fromList <$> mapM (freshElt x) (M.toList $ t_elts t)
                   return (x, t { t_elts = es })
              | otherwise
@@ -671,8 +666,8 @@ subType l err g t1 t2 =
 --   where
 --     sub t1 t2  = subType l g (zipType δ t1 t2) t2
 --     (t1s, t2s) = unzip [ (t1,t2) | pe <- expand True δ (findSymOrDie p δ, ts)
---                                  , ee <- es 
---                                  , sameBinder pe ee 
+--                                  , ee <- es
+--                                  , sameBinder pe ee
 --                                  , let t1 = eltType ee
 --                                  , let t2 = eltType pe ]
 -- safeExtends _ _ _ (ID _ _ _ Nothing _) = return ()
@@ -683,7 +678,7 @@ subType l err g t1 t2 =
 --------------------------------------------------------------------------------
 
 --------------------------------------------------------------------------------
-wellFormed       :: (IsLocated l) => l -> CGEnv -> RefType -> CGM RefType  
+wellFormed       :: (IsLocated l) => l -> CGEnv -> RefType -> CGM RefType
 --------------------------------------------------------------------------------
 wellFormed l g t
   = do modify $ \st -> st { ws = (W g (ci err l) t) : ws st }
@@ -692,7 +687,7 @@ wellFormed l g t
        err = errorWellFormed (srcPos l)
 
 --------------------------------------------------------------------------------
--- | Generating Fresh Values 
+-- | Generating Fresh Values
 --------------------------------------------------------------------------------
 
 class Freshable a where
@@ -704,7 +699,7 @@ class Freshable a where
 
 instance Freshable Integer where
   fresh = do modify $ \st -> st { cg_cnt = 1 + (cg_cnt st) }
-             cg_cnt <$> get 
+             cg_cnt <$> get
 
 instance Freshable F.Symbol where
   fresh = F.tempSymbol (F.symbol "nano") <$> fresh
@@ -724,26 +719,26 @@ instance Freshable [F.Refa] where
 
 instance Freshable F.Reft where
   fresh                  = errorstar "fresh F.Reft"
-  true    (F.Reft (v,_)) = return $ F.Reft (v, []) 
+  true    (F.Reft (v,_)) = return $ F.Reft (v, [])
   refresh (F.Reft (_,_)) = curry F.Reft <$> freshVV <*> fresh
     where freshVV        = F.vv . Just  <$> fresh
 
 instance Freshable F.SortedReft where
   fresh                  = errorstar "fresh F.Reft"
-  true    (F.RR so r)    = F.RR so <$> true r 
+  true    (F.RR so r)    = F.RR so <$> true r
   refresh (F.RR so r)    = F.RR so <$> refresh r
 
 instance Freshable RefType where
   fresh   = errorstar "fresh RefType"
   refresh = mapReftM refresh
-  true    = trueRefType 
+  true    = trueRefType
 
 trueRefType    :: RefType -> CGM RefType
 trueRefType    = mapReftM true
 
 
 --------------------------------------------------------------------------------
--- | Splitting Subtyping Constraints 
+-- | Splitting Subtyping Constraints
 --------------------------------------------------------------------------------
 --
 -- The types that are split should be aligned by type
@@ -758,12 +753,12 @@ splitC :: SubC -> CGM [FixSubC]
 --
 splitC (Sub g i tf1@(TFun s1 xt1s t1 _) tf2@(TFun s2 xt2s t2 _))
   = do bcs       <- bsplitC g i tf1 tf2
-       g'        <- envTyAdds "splitC" i (thisB ++ xt2s) g 
+       g'        <- envTyAdds "splitC" i (thisB ++ xt2s) g
        cs        <- splitOC g i s1 s2
-       cs'       <- concatMapM splitC $ zipWith (Sub g' i) t2s t1s' 
-       cs''      <- splitC $ Sub g' i (F.subst su t1) t2      
+       cs'       <- concatMapM splitC $ zipWith (Sub g' i) t2s t1s'
+       cs''      <- splitC $ Sub g' i (F.subst su t1) t2
        return     $ bcs ++ cs ++ cs' ++ cs''
-    where  
+    where
        thisB      = B (F.symbol "this") <$> maybeToList s2
        t2s        = b_type <$> xt2s
        t1s'       = F.subst su (b_type <$> xt1s)
@@ -773,17 +768,17 @@ splitC (Sub g i tf1@(TFun s1 xt1s t1 _) tf2@(TFun s2 xt2s t2 _))
 -- | TAlls
 --
 splitC (Sub g i (TAll α1 t1) (TAll α2 t2))
-  | α1 == α2 
+  | α1 == α2
   = splitC $ Sub g i t1 t2
-  | otherwise   
-  = splitC $ Sub g i t1 t2' 
-  where 
+  | otherwise
+  = splitC $ Sub g i t1 t2'
+  where
     θ   = fromList [(α2, tVar α1 :: RefType)]
     t2' = apply θ t2
 
 -- | TVars
 --
-splitC (Sub g i t1@(TVar α1 _) t2@(TVar α2 _)) 
+splitC (Sub g i t1@(TVar α1 _) t2@(TVar α2 _))
   | α1 == α2
   = bsplitC g i t1 t2
   | otherwise
@@ -795,9 +790,9 @@ splitC (Sub g i t1@(TApp TUn t1s r1) t2@(TApp TUn t2s _))
   | F.isFalse (F.simplify r1)
   = return []
   | otherwise
-  = (++) <$> bsplitC g i t1 t2 
+  = (++) <$> bsplitC g i t1 t2
          <*> concatMapM splitC (safeZipWith "splitc-3" (Sub g i) s1s s2s)
-    where 
+    where
        s1s = L.sortBy (compare `on` toType) t1s
        s2s = L.sortBy (compare `on` toType) t2s
 
@@ -806,31 +801,31 @@ splitC (Sub g i t1@(TApp TUn t1s _) t2)
   , t1s' <- L.filter (on (/=) toType t2) t1s
   = (++) <$> splitC (Sub g i t1 t2) <*> concatMapM (splitIncompatC g i) t1s'
   | otherwise
-  = splitIncompatC g i t1 
+  = splitIncompatC g i t1
 
 -- |Type references
---  
---  FIXME: restore co/contra-variance 
+--
+--  FIXME: restore co/contra-variance
 --
 splitC (Sub g i t1@(TRef x1 (m1:t1s) r1) t2@(TRef x2 (m2:t2s) r2))
-  -- 
-  -- * Trivial case (do not even descend) 
+  --
+  -- * Trivial case (do not even descend)
   --
   | F.isFalse (F.simplify r1)
   = return []
   --
   -- * Incompatible mutabilities
   --
-  | not (isSubtype g m1 m2) 
+  | not (isSubtype g m1 m2)
   = splitIncompatC g i t1
-  --  
+  --
   -- * Both immutable, same name, non arrays: Co-variant subtyping
   --
-  | x1 == x2 && isImmutable m2 && not (isArr t1) 
+  | x1 == x2 && isImmutable m2 && not (isArr t1)
   = do  cs    <- bsplitC g i t1 t2
         cs'   <- concatMapM splitC $ safeZipWith "splitc-4" (Sub g i) t1s t2s
         return $ cs ++ cs'
-  -- 
+  --
   -- * Non-immutable, same name: invariance
   --
   | x1 == x2 && not (F.isFalse r2)
@@ -842,7 +837,7 @@ splitC (Sub g i t1@(TRef x1 (m1:t1s) r1) t2@(TRef x2 (m2:t2s) r2))
   | x1 == x2
   = bsplitC g i t1 t2
 
-  | otherwise 
+  | otherwise
   = splitIncompatC g i t1
 
 -- | Rest of TApp
@@ -852,16 +847,16 @@ splitC (Sub g i t1@(TApp c1 t1s _) t2@(TApp c2 t2s _))
   = do  cs    <- bsplitC g i t1 t2
         cs'   <- concatMapM splitC ((safeZipWith "splitc-5") (Sub g i) t1s t2s)
         return $ cs ++ cs'
-  | otherwise = splitIncompatC g i t1 
+  | otherwise = splitIncompatC g i t1
 
 -- | These need to be here due to the lack of a folding operation
 --
-splitC (Sub g i t1@(TRef _ _ _) t2) = 
+splitC (Sub g i t1@(TRef _ _ _) t2) =
   case expandType Coercive g t1 of
     Just t1' -> splitC (Sub g i t1' t2)
     Nothing  -> cgError $ errorUnfoldType l t1 where l = srcPos i
 
-splitC (Sub g i t1 t2@(TRef _ _ _)) = 
+splitC (Sub g i t1 t2@(TRef _ _ _)) =
   case expandType Coercive g t2 of
     Just t2' -> splitC (Sub g i t1 t2')
     Nothing  -> cgError $ errorUnfoldType l t2 where l = srcPos i
@@ -879,39 +874,39 @@ splitC (Sub g i@(Ci _ l) t1@(TCons _ e1s r1) t2@(TCons _ e2s _))
 
 splitC (Sub _ _ (TClass _) (TClass _)) = return []
 splitC (Sub _ _ (TModule _) (TModule _)) = return []
-  
-splitC (Sub g i t1 _)
-  = splitIncompatC g i t1 
 
-splitOC g i (Just t) (Just t') = splitC (Sub g i t t') 
+splitC (Sub g i t1 _)
+  = splitIncompatC g i t1
+
+splitOC g i (Just t) (Just t') = splitC (Sub g i t t')
 splitOC _ _ _        _         = return []
 
 ---------------------------------------------------------------------------------------
 splitIncompatC :: CGEnv -> a -> RefType -> CGM [F.SubC a]
 ---------------------------------------------------------------------------------------
 splitIncompatC g i t = bsplitC g i t (mkBot t)
-    
+
 ---------------------------------------------------------------------------------------
 mkBot   :: (F.Reftable r) => RType r -> RType r
 ---------------------------------------------------------------------------------------
 mkBot t = setRTypeR t (F.bot r) where r = rTypeR t
 
--- 
+--
 --  Gather the types of the LHS IMMUTABLE fields and add them to the
 --  environment with the relevant field symbol as binder
 --
---  FIXME: 
+--  FIXME:
 --
 --  * Add special cases: IndexSig ...
 --
 ---------------------------------------------------------------------------------------
-splitEs :: CGEnv 
+splitEs :: CGEnv
         -> F.Symbol
-        -> Cinfo 
-        -> TypeMembers F.Reft -> TypeMembers F.Reft 
+        -> Cinfo
+        -> TypeMembers F.Reft -> TypeMembers F.Reft
         -> CGM [FixSubC]
 ---------------------------------------------------------------------------------------
-splitEs g x i@(Ci _ l) e1s e2s 
+splitEs g x i@(Ci _ l) e1s e2s
   = do  g' <- foldM step g imBs
         concatMapM (uncurry $ splitE g' i) es
   where
@@ -927,7 +922,7 @@ splitEs g x i@(Ci _ l) e1s e2s
 splitE g i (CallSig t1) (CallSig t2) = splitC (Sub g i t1 t2)
 splitE g i (ConsSig t1) (ConsSig t2) = splitC (Sub g i t1 t2)
 
-splitE g i (IndexSig _ _ t1) (IndexSig _ _ t2) 
+splitE g i (IndexSig _ _ t1) (IndexSig _ _ t2)
   = do  cs    <- splitC (Sub g i t1 t2)
         cs'   <- splitC (Sub g i t2 t1)
         return $ cs ++ cs'
@@ -944,12 +939,12 @@ splitE _ _ _ _ = return []
 splitWithMut g i (_,t1) (μf2,t2)
   | isImmutable μf2
   = splitC (Sub g i t1 t2)
-  | otherwise 
+  | otherwise
   = (++) <$> splitC (Sub g i t1 t2)
          <*> splitC (Sub g i t2 t1)
 
 
--- splitMaybe g i (Just t1) (Just t2) = splitC (Sub g i t1 t2) 
+-- splitMaybe g i (Just t1) (Just t2) = splitC (Sub g i t1 t2)
 -- splitMaybe _ _ _         _         = return []
 
 ---------------------------------------------------------------------------------------
@@ -959,21 +954,21 @@ bsplitC :: CGEnv -> a -> RefType -> RefType -> CGM [F.SubC a]
 bsplitC g ci t1 t2 = bsplitC' g ci <$> addInvariant g t1 <*> return t2
 
 bsplitC' g ci t1 t2
-  | F.isFunctionSortedReft r1 && F.isNonTrivialSortedReft r2
+  | F.isFunctionSortedReft r1 && F.isNonTrivial r2
   -- = F.subC (cge_fenv g) F.PTrue (r1 {F.sr_reft = typeofReft t1}) r2 Nothing [] ci
   = F.subC bs p (r1 {F.sr_reft = typeofReft t1}) r2 Nothing [] ci
-  | F.isNonTrivialSortedReft r2
+  | F.isNonTrivial r2
   = F.subC bs p r1 r2 Nothing [] ci
   | otherwise
   = []
   where
-    bs             = foldl F.unionIBindEnv F.emptyIBindEnv 
+    bs             = foldl F.unionIBindEnv F.emptyIBindEnv
                    $ snd <$> F.toListSEnv (cge_fenv g)
     p              = F.pAnd $ cge_guards g
     (r1,r2)        = (rTypeSortedReft t1, rTypeSortedReft t2)
-    typeofReft t   = F.Reft $ (vv t,) [F.RConc $ typeofExpr (F.symbol "function") t
-                                      ,F.RConc $ F.eProp $ vv t ]
-    typeofExpr s t = F.PAtom F.Eq (F.EApp (F.dummyLoc (F.symbol "ttag")) [F.eVar $ vv t]) 
+    typeofReft t   = F.reft (vv t) $ F.pAnd [ typeofExpr (F.symbol "function") t
+                                            , F.eProp $ vv t ]
+    typeofExpr s t = F.PAtom F.Eq (F.EApp (F.dummyLoc (F.symbol "ttag")) [F.eVar $ vv t])
                                   (F.expr $ F.symbolText s)
     vv             = rTypeValueVar
 
@@ -987,19 +982,19 @@ instance PP (F.SortedReft) where
 ---------------------------------------------------------------------------------------
 splitW :: WfC -> CGM [FixWfC]
 ---------------------------------------------------------------------------------------
-splitW (W g i ft@(TFun s ts t _)) 
+splitW (W g i ft@(TFun s ts t _))
   = do let bws = bsplitW g ft i
-       g'     <- envTyAdds "splitW" i ts g 
+       g'     <- envTyAdds "splitW" i ts g
        ws     <- concatMapM splitW (W g' i <$> maybeToList s)
        ws'    <- concatMapM splitW [W g' i ti | B _ ti <- ts]
        ws''   <-            splitW (W g' i t)
        return  $ bws ++ ws ++ ws' ++ ws''
 
-splitW (W g i (TAll _ t)) 
+splitW (W g i (TAll _ t))
   = splitW (W g i t)
 
 splitW (W g i t@(TVar _ _))
-  = return $ bsplitW g t i 
+  = return $ bsplitW g t i
 
 splitW (W g i t@(TApp _ ts _))
   =  do let ws = bsplitW g t i
@@ -1031,36 +1026,36 @@ splitW (W _ _ (TEnum _ ))
 
 splitW (W _ _ t) = error $ render $ text "Not supported in splitW: " <+> pp t
 
-bsplitW g t i 
-  | F.isNonTrivialSortedReft r'
-  = [F.wfC bs r' Nothing i] 
+bsplitW g t i
+  | F.isNonTrivial r'
+  = [F.wfC bs r' Nothing i]
   | otherwise
   = []
-  where 
+  where
     r' = rTypeSortedReft t
-    bs = foldl F.unionIBindEnv F.emptyIBindEnv 
+    bs = foldl F.unionIBindEnv F.emptyIBindEnv
        $ snd <$> F.toListSEnv (cge_fenv g)
 
 
 envTyAdds msg l xts g
-  = envAdds (msg ++ " - envTyAdds " ++ ppshow (srcPos l)) 
+  = envAdds (msg ++ " - envTyAdds " ++ ppshow (srcPos l))
       [(symbolId l x, EE WriteLocal Initialized t) | B x t <- xts] g
 
 
 ------------------------------------------------------------------------------
 cgFunTys :: (IsLocated l, F.Symbolic b, PP x, PP [b])
-         => l 
+         => l
          -> x
-         -> [b] 
-         -> RefType 
+         -> [b]
+         -> RefType
          -> CGM [(Int, ([TVar], Maybe (RefType), [RefType], RefType))]
 ------------------------------------------------------------------------------
-cgFunTys l f xs ft        | Just ts <- bkFuns ft 
+cgFunTys l f xs ft        | Just ts <- bkFuns ft
                           = zip ([0..] :: [Int]) <$> mapM fTy ts
-                          | otherwise            
-                          = cgError $ errorNonFunction (srcPos l) f ft 
+                          | otherwise
+                          = cgError $ errorNonFunction (srcPos l) f ft
   where
-    fTy (αs, s, yts, t)   | Just yts' <- padUndefineds xs yts 
+    fTy (αs, s, yts, t)   | Just yts' <- padUndefineds xs yts
                           = uncurry (αs,s,,) <$> subNoCapture l yts' xs t
                           | otherwise
                           = cgError $ errorArgMismatch (srcPos l)
@@ -1068,15 +1063,15 @@ cgFunTys l f xs ft        | Just ts <- bkFuns ft
 
 -- | Avoids capture of function binders by existing value variables
 subNoCapture _ yts xs t   = (,) <$> mapM (mapReftM ff) ts <*> mapReftM ff t
-  where 
-    -- 
-    -- If the symbols we are about to introduce are already capture by some 
-    -- value variable, then (1) create a fresh value var. and (2) proceed with 
+  where
+    --
+    -- If the symbols we are about to introduce are already capture by some
+    -- value variable, then (1) create a fresh value var. and (2) proceed with
     -- the substitution after replacing with the new val. var.
     --
     ff r@(F.Reft (v,ras)) | v `L.elem` xss
-                          = do v' <- freshVV 
-                               return $ F.subst su $ F.Reft . (v',) 
+                          = do v' <- freshVV
+                               return $ F.subst su $ F.Reft . (v',)
                                       $ F.subst (F.mkSubst [(v, F.expr v')]) ras
                           | otherwise
                           = return $ F.subst su r
@@ -1084,7 +1079,7 @@ subNoCapture _ yts xs t   = (,) <$> mapM (mapReftM ff) ts <*> mapReftM ff t
     freshVV               = F.vv . Just <$> fresh
     xss                   = F.symbol <$> xs
 
-    su                    = F.mkSubst $ safeZipWith "subNoCapture" fSub yts xs 
+    su                    = F.mkSubst $ safeZipWith "subNoCapture" fSub yts xs
 
     ts                    = [ t | B _ t <- yts ]
 
@@ -1095,19 +1090,19 @@ subNoCapture _ yts xs t   = (,) <$> mapM (mapReftM ff) ts <*> mapReftM ff t
 -- | zipType wrapper
 --
 --   FIXME: What is the purpose of this substitution ???
--- 
-zipTypeUpM g x t1 t2 
+--
+zipTypeUpM g x t1 t2
   | Just (f, (F.Reft (s,ras))) <- zipType g x t1 t2
-  = let su  = F.mkSubst [(s, F.expr x)] in 
+  = let su  = F.mkSubst [(s, F.expr x)] in
     let rs  = F.simplify $ F.Reft (s, F.subst su ras) `F.meet` F.uexprReft x in
     return  $ f rs
-  | otherwise 
+  | otherwise
   = cgError $ bugZipType (srcPos x) t1 t2
 
 zipTypeDownM g x t1 t2
   | Just (f, r) <- zipType g x t1 t2
   = return $ f r
-  | otherwise 
+  | otherwise
   = cgError $ bugZipType (srcPos x) t1 t2
 
 -- Local Variables:

--- a/src/Language/Nano/Liquid/Liquid.hs
+++ b/src/Language/Nano/Liquid/Liquid.hs
@@ -29,6 +29,7 @@ import qualified Language.Fixpoint.Config           as C
 import qualified Language.Fixpoint.Types            as F
 import           Language.Fixpoint.Errors
 import           Language.Fixpoint.Misc
+import qualified Language.Fixpoint.Visitor          as V
 import           Language.Fixpoint.Interface        (solve)
 
 import           Language.Nano.Misc                 (mseq)
@@ -46,30 +47,30 @@ import           Language.Nano.Typecheck.Subst
 import qualified Language.Nano.SystemUtils          as A
 import           Language.Nano.Typecheck.Types
 import           Language.Nano.Typecheck.Parse
-import           Language.Nano.Typecheck.Typecheck  (typeCheck) 
+import           Language.Nano.Typecheck.Typecheck  (typeCheck)
 import           Language.Nano.Typecheck.Lookup
 import           Language.Nano.SSA.SSA
 import           Language.Nano.Visitor
 import           Language.Nano.Liquid.Types
 import           Language.Nano.Liquid.CGMonad
-import qualified Data.Text                          as T 
+import qualified Data.Text                          as T
 import           System.Console.CmdArgs.Default
 
 import           Debug.Trace                        (trace)
--- import           Text.PrettyPrint.HughesPJ 
+-- import           Text.PrettyPrint.HughesPJ
 -- import qualified Data.Foldable                      as FO
 
-type PPRS r = (PPR r, Substitutable r (Fact r)) 
+type PPRS r = (PPR r, Substitutable r (Fact r))
 
 --------------------------------------------------------------------------------
 verifyFile    :: Config -> FilePath -> [FilePath] -> IO (A.UAnnSol RefType, F.FixResult Error)
 --------------------------------------------------------------------------------
-verifyFile cfg f fs = parse     fs 
-                    $ ssa 
-                    $ tc    cfg 
+verifyFile cfg f fs = parse     fs
+                    $ ssa
+                    $ tc    cfg
                     $ refTc cfg f
 
-parse fs next 
+parse fs next
   = do  r <- parseNanoFromFiles fs
         donePhase Loud "Parse Files"
         nextPhase r next
@@ -79,8 +80,8 @@ ssa next p
         donePhase Loud "SSA Transform"
         nextPhase r next
 
-tc cfg next p    
-  = do  r <- typeCheck cfg p 
+tc cfg next p
+  = do  r <- typeCheck cfg p
         donePhase Loud "Typecheck"
         nextPhase r next
 
@@ -92,50 +93,60 @@ refTc cfg f p
     cgi = generateConstraints cfg p
 
 nextPhase (Left l)  _    = return (A.NoAnn, l)
-nextPhase (Right x) next = next x 
-  
--- ppCasts (Nano { code = Src fs }) = 
+nextPhase (Right x) next = next x
+
+-- ppCasts (Nano { code = Src fs }) =
 --   fcat $ pp <$> [ (srcPos a, c) | a <- concatMap FO.toList fs
---                                 , TCast _ c <- ann_fact a ] 
-         
+--                                 , TCast _ c <- ann_fact a ]
+
 -- | solveConstraints
 --   Call solve with `ueqAllSorts` enabled.
 --------------------------------------------------------------------------------
-solveConstraints :: NanoRefType 
-                 -> FilePath 
-                 -> CGInfo 
-                 -> IO (A.UAnnSol RefType, F.FixResult Error) 
+solveConstraints :: NanoRefType
+                 -> FilePath
+                 -> CGInfo
+                 -> IO (A.UAnnSol RefType, F.FixResult Error)
 --------------------------------------------------------------------------------
-solveConstraints p f cgi 
-  = do (r, s)  <- solve fpConf f [] $ cgi_finfo cgi
+solveConstraints p f cgi
+  = do (r, s)  <- solve fpConf $ cgi_finfo cgi
        let r'   = fmap (ci_info . F.sinfo) r
-       let ann  = cgi_annot cgi
-       let sol  = applySolution s 
-       return (A.SomeAnn ann sol, r') 
+       let anns = cgi_annot cgi
+       let sol  = applySolution s
+       return (A.SomeAnn anns sol, r')
   where
-    fpConf      = C.withUEqAllSorts def { C.real = real } True 
-    real        = RealOption `elem` pOptions p 
+    real        = RealOption `elem` pOptions p
+    fpConf      = def { C.real        = real
+                      , C.ueqAllSorts = C.UAS True
+                      , C.srcFile     = f
+                      }
+
+-- withUEqAllSorts c b = c { ueqAllSorts = UAS b }
 
 --------------------------------------------------------------------------------
-applySolution :: F.FixSolution -> A.UAnnInfo RefType -> A.UAnnInfo RefType 
+applySolution :: F.FixSolution -> A.UAnnInfo RefType -> A.UAnnInfo RefType
 --------------------------------------------------------------------------------
-applySolution = fmap . fmap . tx
+applySolution  = fmap . fmap . tx
   where
-    tx s (F.Reft (x, zs))   = F.Reft (x, F.squishRefas (appSol s <$> zs))
-    appSol _ ra@(F.RConc _) = ra 
-    appSol s (F.RKvar k su) = F.RConc $ F.subst su $ HM.lookupDefault F.PTop k s  
+    tx         = F.mapPredReft . txPred
+    txPred s   = F.simplify . V.mapKVars (appSol s)
+    appSol s k = Just $ HM.lookupDefault F.PTop k s
+
+    -- tx   s (F.Reft (x, ra)) = F.Reft (x, txRa s ra)
+    -- txRa s                  = F.Refa . F.simplify . V.mapKVars (appSol s) . F.raPred
+    -- appSol _ ra@(F.RConc _) = ra
+    -- appSol s (F.RKvar k su) = F.RConc $ F.subst su $ HM.lookupDefault F.PTop k s
 
 --------------------------------------------------------------------------------
-generateConstraints :: Config -> NanoRefType -> CGInfo 
+generateConstraints :: Config -> NanoRefType -> CGInfo
 --------------------------------------------------------------------------------
 generateConstraints cfg pgm = getCGInfo cfg pgm $ consNano pgm
 
 --------------------------------------------------------------------------------
 consNano :: NanoRefType -> CGM ()
 --------------------------------------------------------------------------------
-consNano p@(Nano {code = Src fs}) 
+consNano p@(Nano {code = Src fs})
   = do  g   <- initGlobalEnv p
-        consStmts g fs 
+        consStmts g fs
         return ()
 
 
@@ -151,12 +162,12 @@ initGlobalEnv pgm@(Nano { code = Src s }) = do
     mapM_ (uncurry $ checkSyms "initFunc" g []) xts
     envAdds "initGlobalEnv" extras g
   where
-    reshuffle1 = \(_,_,c,d,e) -> EE c e d
-    reshuffle2 = \(_,c,d,e)   -> EE c e d
+    reshuffle1 (_,_,c,d,e) = EE c e d
+    reshuffle2 (_,c,d,e)   = EE c e d
     nms        = E.envUnion
-                 (E.envAdds extras    $ E.envMap reshuffle1 
-                                      $ mkVarEnv vars) 
-                 (E.envMap reshuffle2 $ E.envUnionList $ maybeToList 
+                 (E.envAdds extras    $ E.envMap reshuffle1
+                                      $ mkVarEnv vars)
+                 (E.envMap reshuffle2 $ E.envUnionList $ maybeToList
                                       $ m_variables <$> E.qenvFindTy pth mod)
     vars       = visibleVars s
     xts        = [(x,t) | (x,(_,_,_,t,_))<- vars]
@@ -174,7 +185,7 @@ initGlobalEnv pgm@(Nano { code = Src s }) = do
 -------------------------------------------------------------------------------
 initModuleEnv :: (F.Symbolic n, PP n) => CGEnv -> n -> [Statement AnnTypeR] -> CGM CGEnv
 -------------------------------------------------------------------------------
-initModuleEnv g n s = do 
+initModuleEnv g n s = do
     g' <- freshenCGEnvM $ CGE nms bds grd ctx mod cha pth (Just g) cst
     mapM_ (uncurry $ checkSyms "initFunc" g' []) xts
     return g'
@@ -182,7 +193,7 @@ initModuleEnv g n s = do
     reshuffle1 = \(_,_,c,d,e) -> EE c e d
     reshuffle2 = \(_,c,d,e)   -> EE c e d
     nms        = (E.envMap reshuffle1 $ mkVarEnv vars) `E.envUnion`
-                 (E.envMap reshuffle2 $ E.envUnionList $ maybeToList 
+                 (E.envMap reshuffle2 $ E.envUnionList $ maybeToList
                                       $ m_variables <$> E.qenvFindTy pth mod)
     vars       = visibleVars s
     xts        = [(x,t) | (x,(_,_,_,t,_))<- vars]
@@ -194,7 +205,7 @@ initModuleEnv g n s = do
     pth        = extendAbsPath (cge_path g) n
     cst        = cge_consts g
 
--- | `initFuncEnv l f i xs (αs, ts, t) g` 
+-- | `initFuncEnv l f i xs (αs, ts, t) g`
 --
 --    * Pushes a new context @i@
 --    * Adds return type @t@
@@ -241,7 +252,7 @@ initFuncEnv l f i xs (αs,thisTO,ts,t) g s = do
 consEnvFindTypeDefM :: IsLocated a => a -> CGEnv -> AbsName -> CGM (IfaceDef F.Reft)
 -------------------------------------------------------------------------------
 consEnvFindTypeDefM l γ x
-  = case resolveTypeInEnv γ x of 
+  = case resolveTypeInEnv γ x of
       Just t  -> return t
       Nothing -> die $ bugClassDefNotFound (srcPos l) x
 
@@ -253,32 +264,32 @@ consEnvFindTypeDefM l γ x
 --------------------------------------------------------------------------------
 consFun :: CGEnv -> Statement (AnnType F.Reft) -> CGM CGEnv
 --------------------------------------------------------------------------------
-consFun g (FunctionStmt l f xs body) 
+consFun g (FunctionStmt l f xs body)
   = case envFindTy f g of
       Just spec -> do ft        <- cgFunTys l f xs spec
                       forM_ ft   $ consFun1 l g f xs body
                       return     $ g
       Nothing   -> cgError $ errorMissingSpec (srcPos l) f
-       
-consFun _ s 
+
+consFun _ s
   = die $ bug (srcPos s) "consFun called not with FunctionStmt"
 
 -- | @consFun1@ checks a function body against a *one* of multiple
 --   conjuncts of an overloaded (intersection) type signature.
 --   Assume: len ts' = len xs
 
-consFun1 l g f xs body (i, ft) 
+consFun1 l g f xs body (i, ft)
   = initFuncEnv l f i xs ft g body >>= (`consStmts` body)
 
-                                  
+
 --------------------------------------------------------------------------------
-consStmts :: CGEnv -> [Statement AnnTypeR]  -> CGM (Maybe CGEnv) 
+consStmts :: CGEnv -> [Statement AnnTypeR]  -> CGM (Maybe CGEnv)
 --------------------------------------------------------------------------------
 consStmts g stmts = consFold consStmt g stmts
 
 
 --------------------------------------------------------------------------------
-consStmt :: CGEnv -> Statement AnnTypeR -> CGM (Maybe CGEnv) 
+consStmt :: CGEnv -> Statement AnnTypeR -> CGM (Maybe CGEnv)
 --------------------------------------------------------------------------------
 
 -- | @consStmt g s@ returns the environment extended with binders that are
@@ -286,83 +297,83 @@ consStmt :: CGEnv -> Statement AnnTypeR -> CGM (Maybe CGEnv)
 --   statement has (definitely) hit a `return` along the way.
 
 -- skip
-consStmt g (EmptyStmt _) 
+consStmt g (EmptyStmt _)
   = return $ Just g
 
 -- x = e
-consStmt g (ExprStmt l (AssignExpr _ OpAssign (LVar lx x) e))   
+consStmt g (ExprStmt l (AssignExpr _ OpAssign (LVar lx x) e))
   = consAsgn l g (Id lx x) e
 
 -- e1.f = e2
 consStmt g (ExprStmt l (AssignExpr _ OpAssign (LDot _ e1 f) e2))
   = mseq (consExpr g e1 Nothing) $ \(x1,g') -> do
-      t         <- safeEnvFindTy x1 g' 
+      t         <- safeEnvFindTy x1 g'
       let rhsCtx = fmap snd3 $ getProp g' FieldAccess Nothing f t
       opTy      <- setPropTy l (F.symbol f) <$> safeEnvFindTy (builtinOpId BISetProp) g'
       fmap snd <$> consCall g' l BISetProp (FI Nothing [(vr x1, Nothing),(e2, rhsCtx)]) opTy
   where
       vr         = VarRef $ getAnnotation e1
-   
+
 -- e
-consStmt g (ExprStmt _ e) 
+consStmt g (ExprStmt _ e)
   = fmap snd <$> consExpr g e Nothing
 
 -- s1;s2;...;sn
-consStmt g (BlockStmt _ stmts) 
-  = consStmts g stmts 
+consStmt g (BlockStmt _ stmts)
+  = consStmts g stmts
 
 -- if b { s1 }
 consStmt g (IfSingleStmt l b s)
   = consStmt g (IfStmt l b s (EmptyStmt l))
 
---  1. Use @envAddGuard True@ and @envAddGuard False@ to add the binder 
---     from the condition expression @e@ into @g@ to obtain the @CGEnv@ 
---     for the "then" and "else" statements @s1@ and @s2 respectively. 
+--  1. Use @envAddGuard True@ and @envAddGuard False@ to add the binder
+--     from the condition expression @e@ into @g@ to obtain the @CGEnv@
+--     for the "then" and "else" statements @s1@ and @s2 respectively.
 --  2. Recursively constrain @s1@ and @s2@ under the respective environments.
---  3. Combine the resulting environments with @envJoin@ 
+--  3. Combine the resulting environments with @envJoin@
 
 -- if e { s1 } else { s2 }
 consStmt g (IfStmt l e s1 s2) =
-  mseq (safeEnvFindTy (builtinOpId BITruthy) g 
+  mseq (safeEnvFindTy (builtinOpId BITruthy) g
             >>= consCall g l "truthy" (FI Nothing [(e, Nothing)])) $ \(xe,ge) -> do
-    g1'      <- (`consStmt` s1) $ envAddGuard xe True ge 
-    g2'      <- (`consStmt` s2) $ envAddGuard xe False ge 
+    g1'      <- (`consStmt` s1) $ envAddGuard xe True ge
+    g2'      <- (`consStmt` s2) $ envAddGuard xe False ge
     envJoin l g g1' g2'
 
--- while e { s }  
-consStmt g (WhileStmt l e s) 
-  = consWhile g l e s 
+-- while e { s }
+consStmt g (WhileStmt l e s)
+  = consWhile g l e s
 
 -- var x1 [ = e1 ]; ... ; var xn [= en];
 consStmt g (VarDeclStmt _ ds)
   = consFold consVarDecl g ds
-    
--- return 
+
+-- return
 consStmt g (ReturnStmt l Nothing)
-  = do _ <- subType l (errorLiquid' l) g tVoid (envFindReturn g) 
+  = do _ <- subType l (errorLiquid' l) g tVoid (envFindReturn g)
        return Nothing
-       
--- return e 
+
+-- return e
 consStmt g (ReturnStmt l (Just e@(VarRef lv x)))
-  | Just t <- envFindTy x g, needsCall t 
+  | Just t <- envFindTy x g, needsCall t
   = do  g'    <- envAdds "Return" [(fn, EE ReadOnly Initialized $ finalizeTy t)] g
-        consStmt g' (ReturnStmt l (Just (CallExpr l (VarRef lv fn) [e]))) 
-  | otherwise 
+        consStmt g' (ReturnStmt l (Just (CallExpr l (VarRef lv fn) [e])))
+  | otherwise
   = do  _ <- consCall g l "return" (FI Nothing [(e, Just retTy)]) $ returnTy retTy True
         return Nothing
   where
-    retTy = envFindReturn g 
+    retTy = envFindReturn g
     fn    = Id l "__finalize__"
-    needsCall (TRef _ (m:_) _) = isUniqueMutable m 
+    needsCall (TRef _ (m:_) _) = isUniqueMutable m
     needsCall _                = False
 
 consStmt g (ReturnStmt l (Just e))
   = do  _ <- consCall g l "return" (FI Nothing [(e, Just retTy)]) $ returnTy retTy True
         return Nothing
   where
-    retTy = envFindReturn g 
+    retTy = envFindReturn g
 
--- throw e 
+-- throw e
 consStmt g (ThrowStmt _ e)
   = consExpr g e Nothing >> return Nothing
 
@@ -380,10 +391,10 @@ consStmt g s@(FunctionStmt _ _ _ _)
 -- class A<V> [extends B<T>] {..}
 --
 --  * Add the type vars V in the environment
---  
---  * Compute type for "this" and add that to the env as well. 
 --
-consStmt g (ClassStmt l x _ _ ce) 
+--  * Compute type for "this" and add that to the env as well.
+--
+consStmt g (ClassStmt l x _ _ ce)
   = do  dfn <- consEnvFindTypeDefM l g rn
         g'  <- envAdds "class-0" [(Loc (ann l) α, ee $ tVar α) | α <- t_args dfn] g
         consClassElts l g' dfn ce
@@ -403,33 +414,33 @@ consStmt g (ModuleStmt _ n body)
   = initModuleEnv g n body >>= (`consStmts` body) >> return (Just g)
 
 -- OTHER (Not handled)
-consStmt _ s 
+consStmt _ s
   = errorstar $ "consStmt: not handled " ++ ppshow s
 
 
 ------------------------------------------------------------------------------------
-consVarDecl :: CGEnv -> VarDecl AnnTypeR -> CGM (Maybe CGEnv) 
+consVarDecl :: CGEnv -> VarDecl AnnTypeR -> CGM (Maybe CGEnv)
 ------------------------------------------------------------------------------------
 consVarDecl g v@(VarDecl l x (Just e))
   = case scrapeVarDecl v of
-      -- | Local 
-      [ ] ->  
+      -- | Local
+      [ ] ->
         mseq (consExpr g e Nothing) $ \(y,gy) -> do
           t       <- safeEnvFindTy y gy
           Just   <$> envAdds "consVarDecl" [(x, EE WriteLocal Initialized t)] gy
 
-      [(_, WriteLocal, Just t)] -> 
+      [(_, WriteLocal, Just t)] ->
         mseq (consCall g l "consVarDecl" (FI Nothing [(e, Nothing)]) $ localTy t) $ \(y,gy) -> do
           t       <- safeEnvFindTy y gy
           Just   <$> envAdds "consVarDecl" [(x, EE WriteLocal Initialized t)] gy
 
-      [(_, WriteLocal, Nothing)] -> 
+      [(_, WriteLocal, Nothing)] ->
         mseq (consExpr g e Nothing) $ \(y,gy) -> do
           t       <- safeEnvFindTy y gy
           Just   <$> envAdds "consVarDecl" [(x, EE WriteLocal Initialized t)] gy
 
       -- | Global
-      [(_, WriteGlobal, Just t)] -> 
+      [(_, WriteGlobal, Just t)] ->
         mseq (consExpr g e $ Just t) $ \(y, gy) -> do
           ty      <- safeEnvFindTy y gy
           fta     <- freshenType WriteGlobal gy l t
@@ -437,7 +448,7 @@ consVarDecl g v@(VarDecl l x (Just e))
           _       <- subType l (errorLiquid' l) gy fta t
           Just   <$> envAdds "consVarDecl" [(x, EE WriteGlobal Initialized fta)] gy
 
-      [(_, WriteGlobal, Nothing)] -> 
+      [(_, WriteGlobal, Nothing)] ->
         mseq (consExpr g e Nothing) $ \(y, gy) -> do
           ty      <- safeEnvFindTy y gy
           fta     <- refresh ty >>= wellFormed l g
@@ -445,29 +456,29 @@ consVarDecl g v@(VarDecl l x (Just e))
           Just   <$> envAdds "consVarDecl" [(x, EE WriteGlobal Initialized fta)] gy
 
       -- | ReadOnly
-      [(_, ReadOnly, Just t)] -> 
+      [(_, ReadOnly, Just t)] ->
         mseq (consCall g l "consVarDecl" (FI Nothing [(e, Nothing)]) $ localTy t) $ \(y,gy) -> do
           t       <- safeEnvFindTy y gy
           Just   <$> envAdds "consVarDecl" [(x, EE ReadOnly Initialized t)] gy
- 
-      [(_, ReadOnly, Nothing)] -> 
+
+      [(_, ReadOnly, Nothing)] ->
         mseq (consExpr g e Nothing) $ \(y,gy) -> do
           t       <- safeEnvFindTy y gy
           Just   <$> envAdds "consVarDecl" [(x, EE ReadOnly Initialized t)] gy
-         
+
       _ -> cgError $ errorVarDeclAnnot (srcPos l) x
- 
+
 consVarDecl g v@(VarDecl _ x Nothing)
   = case scrapeVarDecl v of
       -- special case ambient vars
-      [(AmbVarDeclKind, _, Just t)] -> 
-        Just <$> envAdds "consVarDecl" [(x, EE ReadOnly Initialized t)] g      
+      [(AmbVarDeclKind, _, Just t)] ->
+        Just <$> envAdds "consVarDecl" [(x, EE ReadOnly Initialized t)] g
       -- The rest should have fallen under the 'undefined' initialization case
-      _ -> error "LQ: consVarDecl this shouldn't happen" 
+      _ -> error "LQ: consVarDecl this shouldn't happen"
 
 ------------------------------------------------------------------------------------
-consExprT :: AnnTypeR -> CGEnv -> Expression AnnTypeR -> Maybe RefType 
-          -> CGM (Maybe (Id AnnTypeR, CGEnv)) 
+consExprT :: AnnTypeR -> CGEnv -> Expression AnnTypeR -> Maybe RefType
+          -> CGM (Maybe (Id AnnTypeR, CGEnv))
 ------------------------------------------------------------------------------------
 consExprT _ g e Nothing  = consExpr g e Nothing
 consExprT l g e (Just t) = consCall  g l "consExprT" (FI Nothing [(e, Nothing)])
@@ -476,7 +487,7 @@ consExprT l g e (Just t) = consCall  g l "consExprT" (FI Nothing [(e, Nothing)])
 ------------------------------------------------------------------------------------
 consClassElts :: IsLocated l => l -> CGEnv -> IfaceDef F.Reft -> [ClassElt AnnTypeR] -> CGM ()
 ------------------------------------------------------------------------------------
-consClassElts l g d@(ID nm _ vs _ es) cs 
+consClassElts l g d@(ID nm _ vs _ es) cs
   = do  g0   <- envAdds "consClassElts-2" thisInfo g
         g1   <- envAdds "consClassElts-1" fs g0  -- Add imm fields into scope beforehand
         mapM_ (consClassElt g1 d) cs
@@ -485,7 +496,7 @@ consClassElts l g d@(ID nm _ vs _ es) cs
                               , isImmutable m ]
     -- TODO: Make location more precise
     --
-    -- PV: qualified name here used as key -> ok 
+    -- PV: qualified name here used as key -> ok
     ql        = mkQualSym $ F.symbol thisId
     ro        = ReadOnly
     ii        = Initialized
@@ -496,12 +507,12 @@ consClassElts l g d@(ID nm _ vs _ es) cs
 ------------------------------------------------------------------------------------
 consClassElt :: CGEnv -> IfaceDef F.Reft -> ClassElt AnnTypeR -> CGM ()
 ------------------------------------------------------------------------------------
-consClassElt g d@(ID nm _ vs _ ms) (Constructor l xs body) 
+consClassElt g d@(ID nm _ vs _ ms) (Constructor l xs body)
   = do  g0       <- envAdds "Constructor" [(ctorExit, eri mkCtorExitTy)] g
         g1       <- envAdds "classElt-ctor-1" superInfo g0
         ts       <- cgFunTys l ctor xs ctorTy
         forM_ ts  $ consFun1 l g1 ctor xs body
-  where 
+  where
     this_t        = TRef nm (tVar <$> vs) fTop
     ctor          = Loc (srcPos l) $ builtinOpId BICtor
     ctorExit      = Loc (srcPos l) $ builtinOpId BICtorExit
@@ -513,25 +524,25 @@ consClassElt g d@(ID nm _ vs _ ms) (Constructor l xs body)
 
     mkCtorExitTy  = substOffsetThis $ mkFun (vs, Nothing, bs, ret)
       where
-        ret       = this_t `strengthen` F.Reft (F.vv Nothing, fbind <$> out)
+        ret       = this_t `strengthen` F.reft (F.vv Nothing) (F.pAnd $ fbind <$> out)
         bs        | Just (TCons _ ms _) <- expandType Coercive g this_t
-                  = sortBy c_sym [ B f t' | ((_,InstanceMember),(FieldSig f _ _ t)) <- M.toList ms
-                                          , F.symbol f /= protoSym 
+                  = sortBy c_sym [ B f t' | ((_,InstanceMember), FieldSig f _ _ t) <- M.toList ms
+                                          , F.symbol f /= protoSym
                                           , let t' = unqualifyThis g this_t t ]
                   | otherwise
                   = []
         out       | Just (TCons _ ms _) <- expandType Coercive g this_t
-                  = [ f | ((_,InstanceMember),(FieldSig f _ m _)) <- M.toList ms
+                  = [ f | ((_,InstanceMember), FieldSig f _ m _) <- M.toList ms
                         , isImmutable m, F.symbol f /= protoSym ]
                   | otherwise
                   = []
 
-    fbind f       = F.RConc $ F.PAtom F.Eq (mkOffset v_sym $ F.symbolString f) (F.eVar f)
+    fbind f       = F.PAtom F.Eq (mkOffset v_sym $ F.symbolString f) (F.eVar f)
 
     v_sym         = F.symbol $ F.vv Nothing
     c_sym         = on compare b_sym
 
-    -- This works now cause each class is required to have a constructor 
+    -- This works now cause each class is required to have a constructor
     ctorTy        = mkAnd [mkAll vs $ remThisBinding t | ConsSig t <- M.elems ms ]
 
 -- | Static field
@@ -542,17 +553,17 @@ consClassElt g dfn (MemberVarDecl l True x (Just e))
   = cgError $ errorClassEltAnnot (srcPos l) (t_name dfn) x
   where
     spec      = M.lookup (F.symbol x, StaticMember) (t_elts dfn)
- 
+
 consClassElt _ _ (MemberVarDecl l True x Nothing)
   = cgError $ unsupportedStaticNoInit (srcPos l) x
 
--- | Instance variable (checked at ctor) 
+-- | Instance variable (checked at ctor)
 consClassElt _ _ (MemberVarDecl _ False _ Nothing)
-  = return () 
+  = return ()
 
 consClassElt _ _ (MemberVarDecl l False x _)
   = die $ bugClassInstVarInit (srcPos l) x
-  
+
 -- | Static method
 consClassElt g dfn (MemberMethDef l True x xs body)
   | Just (MethSig _ t) <- M.lookup (F.symbol x,StaticMember) (t_elts dfn)
@@ -560,9 +571,9 @@ consClassElt g dfn (MemberMethDef l True x xs body)
         mapM_ (consFun1 l g x xs body) its
   | otherwise
   = cgError  $ errorClassEltAnnot (srcPos l) (t_name dfn) x
- 
+
 -- | Instance method
-consClassElt g (ID nm _ vs _ es) (MemberMethDef l False x xs body) 
+consClassElt g (ID nm _ vs _ es) (MemberMethDef l False x xs body)
   | Just (MethSig _ t) <- M.lookup (F.symbol x, InstanceMember) es
   = do  ft     <- cgFunTys l x xs t
         mapM_     (consFun1 l g x xs body) $ mapSnd procFT <$> ft
@@ -579,7 +590,7 @@ consClassElt g (ID nm _ vs _ es) (MemberMethDef l False x xs body)
             slf Nothing           = mkThis t_readOnly vs
 
     mkThis m (_:αs)       = TRef an (ofType m : map tVar αs) fTop
-    mkThis _ _            = throw $ bug (srcPos l) "Liquid.Liquid.consClassElt MemberMethDef" 
+    mkThis _ _            = throw $ bug (srcPos l) "Liquid.Liquid.consClassElt MemberMethDef"
 
     an                    = QN AK_ (srcPos l) ss (F.symbol nm)
 
@@ -592,7 +603,7 @@ consClassElt _ _  (MemberMethDecl _ _ _ _) = return ()
 consAsgn :: AnnTypeR -> CGEnv -> Id AnnTypeR -> Expression AnnTypeR -> CGM (Maybe CGEnv)
 --------------------------------------------------------------------------------
 consAsgn l g x e =
-  case envFindTyWithAsgn x g of 
+  case envFindTyWithAsgn x g of
     -- This is the first time we initialize this variable
     Just (EE WriteGlobal Uninitialized t) ->
       do  t' <- freshenType WriteGlobal g l t
@@ -600,7 +611,7 @@ consAsgn l g x e =
             g'' <- envAdds "consAsgn-0" [(x, EE WriteGlobal Initialized t')] g'
             return $ Just g''
 
-    Just (EE WriteGlobal _ t) -> mseq (consExprT l g e $ Just t) $ \(_, g') -> 
+    Just (EE WriteGlobal _ t) -> mseq (consExprT l g e $ Just t) $ \(_, g') ->
                                    return $ Just g'
     Just (EE a i t)           -> mseq (consExprT l g e $ Just t) $ \(x', g') -> do
                                    t      <- safeEnvFindTy x' g'
@@ -610,7 +621,7 @@ consAsgn l g x e =
                                    Just  <$> envAdds "consAsgn-1" [(x, EE WriteLocal Initialized t)] g'
 
 
--- | @consExpr g e@ returns a pair (g', x') where x' is a fresh, 
+-- | @consExpr g e@ returns a pair (g', x') where x' is a fresh,
 -- temporary (A-Normalized) variable holding the value of `e`,
 -- g' is g extended with a binding for x' (and other temps required for `e`)
 ------------------------------------------------------------------------------------
@@ -625,7 +636,7 @@ consExpr g (Cast_ l e) _ =
 
 -- | < t > e
 consExpr g ex@(Cast l e) _ =
-  case [ ct | UserCast ct <- ann_fact l ] of 
+  case [ ct | UserCast ct <- ann_fact l ] of
     [t] -> consCast g l e t
     _   -> die $ bugNoCasts (srcPos l) ex
 
@@ -640,7 +651,7 @@ consExpr g (HexLit l x) _
   = Just <$> envAddFresh "10" l (tBV32, WriteLocal, Initialized) g
 
 consExpr g (BoolLit l b) _
-  = Just <$> envAddFresh "11" l (pSingleton tBool b, WriteLocal, Initialized) g 
+  = Just <$> envAddFresh "11" l (pSingleton tBool b, WriteLocal, Initialized) g
 
 consExpr g (StringLit l s) _
   = Just <$> envAddFresh "12" l (tString `eSingleton` T.pack s, WriteLocal, Initialized) g
@@ -650,10 +661,10 @@ consExpr g (NullLit l) _
 
 consExpr g (ThisRef l) _
   = case envFindTyWithAsgn this g of
-      Just _  -> return  $ Just (this,g) 
-      Nothing -> cgError $ errorUnboundId (ann l) "this" 
+      Just _  -> return  $ Just (this,g)
+      Nothing -> cgError $ errorUnboundId (ann l) "this"
   where
-    this = Id l "this" 
+    this = Id l "this"
 
 consExpr g (VarRef l x) _
   | Just (EE WriteGlobal i t) <- tInfo
@@ -662,7 +673,7 @@ consExpr g (VarRef l x) _
   = addAnnot (srcPos l) x t >> return (Just (x, g))
   | otherwise
   = cgError $ errorUnboundId (ann l) x
-  where 
+  where
     tInfo = envFindTyWithAsgn x g
 
 consExpr g (PrefixExpr l o e) _
@@ -678,7 +689,7 @@ consExpr g (InfixExpr l o@OpInstanceof e1 e2) _
          _          -> cgError $ unimplemented (srcPos l) "tcCall-instanceof" $ ppshow e2
   where
     l2 = getAnnotation e2
-    cc (QN AK_ _ _ s) = F.symbolString s 
+    cc (QN AK_ _ _ s) = F.symbolString s
 
 consExpr g (InfixExpr l o e1 e2) _
   = do opTy <- safeEnvFindTy (infixOpId o) g
@@ -689,13 +700,13 @@ consExpr g (CondExpr l e e1 e2) to
   = do  opTy    <- mkTy to <$> safeEnvFindTy (builtinOpId BICondExpr) g
         tt'     <- freshTyFun g l (rType tt)
         (v,g')  <- mapFst (VarRef l) <$> envAddFresh "14" l (tt', WriteLocal, Initialized) g
-        consCallCondExpr g' l BICondExpr 
-          (FI Nothing $ [(e,Nothing),(v,Nothing),(e1,rType <$> to),(e2,rType <$> to)]) 
+        consCallCondExpr g' l BICondExpr
+          (FI Nothing $ [(e,Nothing),(v,Nothing),(e1,rType <$> to),(e2,rType <$> to)])
           opTy
         -- consCallCondExpr g' l BICondExpr (FI Nothing ((,Nothing) <$> [e,v,e1,e2])) opTy
   where
     tt       = fromMaybe tTop to
-    mkTy Nothing (TAll cv (TAll tv (TFun Nothing [B c_ tc, B t_ _   , B x_ xt, B y_ yt] o r))) = 
+    mkTy Nothing (TAll cv (TAll tv (TFun Nothing [B c_ tc, B t_ _   , B x_ xt, B y_ yt] o r))) =
                   TAll cv (TAll tv (TFun Nothing [B c_ tc, B t_ tTop, B x_ xt, B y_ yt] o r))
     mkTy _ t = t
 
@@ -703,7 +714,7 @@ consExpr g (CondExpr l e e1 e2) to
 consExpr g (CallExpr l (SuperRef _) es) _
   | Just t            <- envFindTy (builtinOpId BIThis) g
   , Just (TRef x _ _) <- extractParent g t
-  , Just ct           <- extractCtor g (TClass x) 
+  , Just ct           <- extractCtor g (TClass x)
   = consCall g l "super" (FI Nothing ((,Nothing) <$> es)) ct
   | otherwise
   = cgError $ errorUnboundId (ann l) "super"
@@ -713,7 +724,7 @@ consExpr g c@(CallExpr l em@(DotRef _ e f) es) _
   = mseq (consExpr g e Nothing) $ \(x,g') -> safeEnvFindTy x g' >>= go g' x
   where
              -- Variadic call error
-    go g x t | isVariadicCall f, [] <- es 
+    go g x t | isVariadicCall f, [] <- es
              = cgError $ errorVariadicNoArgs (srcPos l) em
 
              -- Variadic call
@@ -721,18 +732,18 @@ consExpr g c@(CallExpr l em@(DotRef _ e f) es) _
              = consCall g l em (argsThis v vs) t
 
              -- Accessing and calling a function field
-             -- 
-             -- FIXME: 'this' should not appear in ft 
-             --        Add check for this. 
-             -- 
+             --
+             -- FIXME: 'this' should not appear in ft
+             --        Add check for this.
+             --
              | Just (_,ft,_) <- getProp g FieldAccess Nothing f t, isTFun ft
              = consCall g l c (args es) ft
 
              -- Invoking a method
              | Just (_,ft,_) <- getProp g MethodAccess Nothing f t
              = consCall g l c (argsThis (vr x) es) ft
-                                
-             | otherwise 
+
+             | otherwise
              = cgError $ errorCallNotFound (srcPos l) e f
 
     isVariadicCall f = F.symbol f == F.symbol "call"
@@ -743,27 +754,27 @@ consExpr g c@(CallExpr l em@(DotRef _ e f) es) _
 -- | e(es)
 --
 consExpr g (CallExpr l e es) _
-  = mseq (consExpr g e Nothing) $ \(x, g') -> 
+  = mseq (consExpr g e Nothing) $ \(x, g') ->
       safeEnvFindTy x g' >>= consCall g' l e (FI Nothing ((,Nothing) <$> es))
 
 -- | e.f
 --
---   Returns type: { v: _ | v = x.f }, if e => x and `f` is an immutable field 
---                 { v: _ | _       }, otherwise  
+--   Returns type: { v: _ | v = x.f }, if e => x and `f` is an immutable field
+--                 { v: _ | _       }, otherwise
 --
 --   The TC phase should have resolved whether we need to restrict the range of
 --   the type of `e` (possibly adding a relevant cast). So no need to repeat the
---   call here. 
+--   call here.
 --
 consExpr g (DotRef l e f) to
   = mseq (consExpr g e Nothing) $ \(x,g') -> do
       te <- safeEnvFindTy x g'
       case getProp g' FieldAccess Nothing f te of
-        -- 
+        --
         -- Special-casing Array.length
-        -- 
-        Just (TRef (QN _ _ [] s) _ _, _, _) 
-          | F.symbol "Array" == s && F.symbol "length" == F.symbol f -> 
+        --
+        Just (TRef (QN _ _ [] s) _ _, _, _)
+          | F.symbol "Array" == s && F.symbol "length" == F.symbol f ->
               consExpr g' (CallExpr l (DotRef l (vr x) (Id l "_get_length_")) []) to
 
         -- Do not nubstrengthen enumeration fields
@@ -781,7 +792,7 @@ consExpr g (DotRef l e f) to
 -- | e1[e2]
 consExpr g e@(BracketRef l e1 e2) _
   = mseq (consExpr g e1 Nothing) $ \(x1,g') -> do
-      opTy <- do  safeEnvFindTy x1 g' >>= \case 
+      opTy <- do  safeEnvFindTy x1 g' >>= \case
                     TEnum _ -> cgError $ unimplemented (srcPos l) msg e
                     _       -> safeEnvFindTy (builtinOpId BIBracketRef) g'
       consCall g' l BIBracketRef (FI Nothing ((,Nothing) <$> [vr x1, e2])) opTy
@@ -811,12 +822,12 @@ consExpr g (NewExpr l e es) _
       t <- safeEnvFindTy x g'
       case extractCtor g t of
         Just ct -> consCall g l "constructor" (FI Nothing ((,Nothing) <$> es)) ct
-        Nothing -> cgError $ errorConstrMissing (srcPos l) t 
+        Nothing -> cgError $ errorConstrMissing (srcPos l) t
 
 -- | super
 consExpr g (SuperRef l) _
-  = case envFindTy thisId g of 
-      Just t   -> case extractParent g t of 
+  = case envFindTy thisId g of
+      Just t   -> case extractParent g t of
                     Just tp -> Just <$> envAddFresh "15" l (tp, WriteGlobal, Initialized) g
                     Nothing -> cgError $ errorSuper (ann l)
       Nothing  -> cgError $ errorSuper (ann l)
@@ -832,8 +843,8 @@ consExpr g (FuncExpr l fo xs body) tCxtO
     consFuncExpr ft = do kft       <-  freshTyFun g l ft
                          fts       <-  cgFunTys l f xs kft
                          forM_ fts  $  consFun1 l g f xs body
-                         Just      <$> envAddFresh "16" l (kft, WriteLocal, Initialized) g 
-  
+                         Just      <$> envAddFresh "16" l (kft, WriteLocal, Initialized) g
+
     anns            = [ t | FuncAnn t <- ann_fact l ]
     f               = maybe (F.symbol "<anonymous>") F.symbol fo
 
@@ -849,9 +860,9 @@ consCast g l e tc
   = do  opTy    <- safeEnvFindTy (builtinOpId BICastExpr) g
         tc'     <- freshTyFun g l (rType tc)
         (x,g')  <- envAddFresh "3" l (tc', WriteLocal, Initialized) g
-        consCall g' l "user-cast" (FI Nothing [(VarRef l x, Nothing),(e, Just tc')]) opTy 
-                      
--- | Dead code 
+        consCall g' l "user-cast" (FI Nothing [(VarRef l x, Nothing),(e, Just tc')]) opTy
+
+-- | Dead code
 --   Only prove the top-level false.
 consDeadCode g l e t
   = do subType l e g t tBot
@@ -876,34 +887,34 @@ consDownCast g l x _ t2
 
 
 -- | `consCall g l fn ets ft0`:
---   
---   * @ets@ is the list of arguments, as pairs of expressions and optionally 
+--
+--   * @ets@ is the list of arguments, as pairs of expressions and optionally
 --     contextual types on them.
 --   * @ft0@ is the function's signature -- the 'this' argument should have been
 --     made explicit by this point.
 --
 --------------------------------------------------------------------------------
-consCall :: PP a 
-         => CGEnv 
-         -> AnnTypeR 
-         -> a 
+consCall :: PP a
+         => CGEnv
+         -> AnnTypeR
+         -> a
          -> FuncInputs (Expression AnnTypeR, Maybe RefType)
-         -> RefType 
+         -> RefType
          -> CGM (Maybe (Id AnnTypeR, CGEnv))
 --------------------------------------------------------------------------------
 
---   1. Fill in @instantiateFTy@ to get a monomorphic instance of @ft@ 
---      i.e. the callee's RefType, at this call-site (You may want 
+--   1. Fill in @instantiateFTy@ to get a monomorphic instance of @ft@
+--      i.e. the callee's RefType, at this call-site (You may want
 --      to use @freshTyInst@)
 --   2. Use @consExpr@ to determine types for arguments @es@
 --   3. Use @subType@ to add constraints between the types from (step 2) and (step 1)
 --   4. Use the @F.subst@ returned in 3. to substitute formals with actuals in output type of callee.
 
-consCall g l fn ets ft0 
+consCall g l fn ets ft0
   = mseq (consScan consExpr g ets) $ \(xes, g') -> do
-      -- ts <- ltracePP l ("LQ " ++ ppshow fn) <$> T.mapM (`safeEnvFindTy` g') xes 
-      ts <- T.mapM (`safeEnvFindTy` g') xes 
-      case ol of 
+      -- ts <- ltracePP l ("LQ " ++ ppshow fn) <$> T.mapM (`safeEnvFindTy` g') xes
+      ts <- T.mapM (`safeEnvFindTy` g') xes
+      case ol of
         -- If multiple are valid, pick the first one
         (ft:_) -> consInstantiate l g' fn ft ts xes
         _      -> cgError $ errorNoMatchCallee (srcPos l) fn (toType <$> ts) (toType <$> callSigs)
@@ -913,24 +924,24 @@ consCall g l fn ets ft0
               , lt <- callSigs
               , arg_type (toType t) == arg_type (toType lt) ]
     callSigs  = extractCall g ft0
-    arg_type t = (\(a,b,c,_) -> (a,b,c)) <$> bkFun t 
-   
-    
+    arg_type t = (\(a,b,c,_) -> (a,b,c)) <$> bkFun t
+
+
 balance (FI (Just to) ts) (FI Nothing fs)  = (FI (Just to) ts, FI (Just $ B (F.symbol "this") to) fs)
 balance (FI Nothing ts)   (FI (Just _) fs) = (FI Nothing ts, FI Nothing fs)
-balance ts                fs               = (ts, fs) 
+balance ts                fs               = (ts, fs)
 
 --------------------------------------------------------------------------------
 consInstantiate :: PP a
-                => AnnTypeR 
-                -> CGEnv 
-                -> a 
-                -> RefType                          -- Function spec 
+                => AnnTypeR
+                -> CGEnv
+                -> a
+                -> RefType                          -- Function spec
                 -> FuncInputs RefType               -- Input types
                 -> FuncInputs (Id AnnTypeR)         -- Input ids
                 -> CGM (Maybe (Id AnnTypeR, CGEnv))
 --------------------------------------------------------------------------------
-consInstantiate l g fn ft ts xes 
+consInstantiate l g fn ft ts xes
   = do  (_,its1,ot)     <- instantiateFTy l g fn ft
         ts1             <- idxMapFI (instantiateTy l g) 1 ts
         let (ts2, its2)  = balance ts1 its1
@@ -940,7 +951,7 @@ consInstantiate l g fn ft ts xes
   where
     toList (FI x xs)     = maybeToList x ++ xs
     err                  = errorLiquid' l
-    
+
     idxMapFI f i (FI Nothing ts)  = FI     Nothing        <$> mapM (uncurry f) (zip [i..] ts)
     idxMapFI f i (FI (Just t) ts) = FI <$> Just <$> f i t <*> mapM (uncurry f) (zip [(i+1)..] ts)
 
@@ -948,47 +959,47 @@ consInstantiate l g fn ft ts xes
 
 -- Special casing conditional expression call here because we'd like the
 -- arguments to be typechecked under a different guard each.
-consCallCondExpr g l fn ets ft0 
+consCallCondExpr g l fn ets ft0
   = mseq (consCondExprArgs (srcPos l) g ets) $ \(xes, g') -> do
       ts <- T.mapM (`safeEnvFindTy` g') xes
       case [ lt | Overload cx t <- ann_fact l
                 , cge_ctx g == cx
                 , lt <- callSigs
-                , toType t == toType lt ] of 
+                , toType t == toType lt ] of
         [ft] -> consInstantiate l g' fn ft ts xes
         _    -> cgError $ errorNoMatchCallee (srcPos l) fn (toType <$> ts) (toType <$> callSigs)
   where
     callSigs    = extractCall g ft0
-  
+
 ----------------------------------------------------------------------------------
 instantiateTy :: AnnTypeR -> CGEnv -> Int -> RefType -> CGM RefType
 ----------------------------------------------------------------------------------
 instantiateTy l g i t = freshTyInst l g αs ts t'
-    where 
+    where
       (αs, t')        = bkAll t
       ts              = envGetContextTypArgs i g l αs
 
 ---------------------------------------------------------------------------------
-instantiateFTy :: (PP a, PPRS F.Reft) 
-               => AnnTypeR -> CGEnv -> a -> RefType 
+instantiateFTy :: (PP a, PPRS F.Reft)
+               => AnnTypeR -> CGEnv -> a -> RefType
                -> CGM  ([TVar], FuncInputs (Bind F.Reft), RefType)
 ---------------------------------------------------------------------------------
-instantiateFTy l g fn ft 
+instantiateFTy l g fn ft
   = do  t'   <- freshTyInst l g αs ts t
-        maybe err return $ bkFunBinds t' 
-    where 
+        maybe err return $ bkFunBinds t'
+    where
       (αs, t) = bkAll ft
       ts      = envGetContextTypArgs 0 g l αs
-      err     = cgError $ errorNonFunction (srcPos l) fn ft  
+      err     = cgError $ errorNonFunction (srcPos l) fn ft
 
 -----------------------------------------------------------------------------------
-consScan :: (CGEnv -> a -> b -> CGM (Maybe (c, CGEnv))) -> CGEnv -> FuncInputs (a,b) 
+consScan :: (CGEnv -> a -> b -> CGM (Maybe (c, CGEnv))) -> CGEnv -> FuncInputs (a,b)
          -> CGM (Maybe (FuncInputs c, CGEnv))
 -----------------------------------------------------------------------------------
 consScan f g (FI (Just x) xs)
-  = do  z  <- (uncurry $ f g) x 
+  = do  z  <- (uncurry $ f g) x
         case z of
-          Just (x', g') -> 
+          Just (x', g') ->
               do zs  <- fmap (mapFst reverse) <$> consFold step ([], g') xs
                  case zs of
                    Just (xs', g'') -> return $ Just (FI (Just x') xs', g'')
@@ -997,53 +1008,53 @@ consScan f g (FI (Just x) xs)
   where
     step (ys, g) (x,y) = fmap (mapFst (:ys))   <$> f g x y
 
-consScan f g (FI Nothing xs) 
+consScan f g (FI Nothing xs)
   = do  z <- fmap (mapFst reverse) <$> consFold step ([], g) xs
-        case z of 
+        case z of
           Just (xs', g') -> return $ Just (FI Nothing xs', g')
-          _              -> return $ Nothing 
+          _              -> return $ Nothing
   where
     step (ys, g) (x,y) = fmap (mapFst (:ys))   <$> f g x y
- 
+
 
 ---------------------------------------------------------------------------------
-consCondExprArgs :: SrcSpan 
-                 -> CGEnv 
-                 -> FuncInputs (Expression AnnTypeR, Maybe RefType) 
+consCondExprArgs :: SrcSpan
+                 -> CGEnv
+                 -> FuncInputs (Expression AnnTypeR, Maybe RefType)
                  -> CGM (Maybe (FuncInputs (Id AnnTypeR), CGEnv))
 ---------------------------------------------------------------------------------
 consCondExprArgs l g (FI Nothing [(c,tc),(t,tt),(x,tx),(y,ty)])
   = mseq (consExpr g c tc) $ \(c_,gc) ->
-      mseq (consExpr gc t tt) $ \(t_,gt) -> 
-        withGuard gt c_ True x tx >>= \case 
-          Just (x_, gx) ->              
+      mseq (consExpr gc t tt) $ \(t_,gt) ->
+        withGuard gt c_ True x tx >>= \case
+          Just (x_, gx) ->
               withGuard gx c_ False y ty >>= \case
                 Just (y_, gy) -> return $ Just (FI Nothing [c_,t_,x_,y_], gy)
-                Nothing -> 
+                Nothing ->
                     do ttx       <- safeEnvFindTy x_ gx
                        let tty    = fromMaybe ttx ty    -- Dummy type if ty is Nothing
                        (y_, gy') <- envAddFresh "6" l (tty, WriteLocal, Initialized) gx
                        return    $ Just (FI Nothing [c_,t_,x_,y_], gy')
-          Nothing -> 
+          Nothing ->
               withGuard gt c_ False y ty >>= \case
-                Just (y_, gy) -> 
+                Just (y_, gy) ->
                     do tty       <- safeEnvFindTy y_ gy
                        let ttx    = fromMaybe tty tx    -- Dummy type if tx is Nothing
                        (x_, gx') <- envAddFresh "7" l (ttx, WriteLocal, Initialized) gy
                        return     $ Just (FI Nothing [c_,t_,x_,y_], gx')
-                Nothing       -> return $ Nothing 
+                Nothing       -> return $ Nothing
   where
-    withGuard g cond b x tx = 
+    withGuard g cond b x tx =
       fmap (mapSnd envPopGuard) <$> consExpr (envAddGuard cond b g) x tx
 
 consCondExprArgs l _ _ = cgError $ impossible l "consCondExprArgs"
-    
+
 
 ---------------------------------------------------------------------------------
 consFold :: (t -> b -> CGM (Maybe t)) -> t -> [b] -> CGM (Maybe t)
 ---------------------------------------------------------------------------------
-consFold f          = foldM step . Just 
-  where 
+consFold f          = foldM step . Just
+  where
     step Nothing _  = return Nothing
     step (Just g) x = f g x
 
@@ -1053,7 +1064,7 @@ consWhile :: CGEnv -> AnnTypeR -> Expression AnnTypeR -> Statement AnnTypeR -> C
 ---------------------------------------------------------------------------------
 
 {- Typing Rule for `while (cond) {body}`
-   
+
       (a) xtIs         <- fresh G [ G(x) | x <- Φ]
       (b) GI            = G, xtIs
       (c) G            |- G(x)  <: GI(x)  , ∀x∈Φ      [base]
@@ -1063,14 +1074,14 @@ consWhile :: CGEnv -> AnnTypeR -> Expression AnnTypeR -> Statement AnnTypeR -> C
       ---------------------------------------------------------
           G            |- while[Φ] (cond) body :: GI', xc:false
 
-   The above rule assumes that phi-assignments have already been inserted. That is, 
-    
+   The above rule assumes that phi-assignments have already been inserted. That is,
+
       i = 0;
       while (i < n){
         i = i + 1;
       }
 
-   Has been SSA-transformed to 
+   Has been SSA-transformed to
 
       i_0 = 0;
       i_2 = i_0;
@@ -1080,29 +1091,29 @@ consWhile :: CGEnv -> AnnTypeR -> Expression AnnTypeR -> Statement AnnTypeR -> C
       }
 
 -}
-consWhile g l cond body 
+consWhile g l cond body
 -- XXX: The RHS ty comes from PhiVarTy
-  = do  (gI,tIs)            <- freshTyPhis l g xs ts                            -- (a) (b) 
+  = do  (gI,tIs)            <- freshTyPhis l g xs ts                            -- (a) (b)
         _                   <- consWhileBase l xs tIs g                         -- (c)
         mseq (consExpr gI cond Nothing) $ \(xc, gI') ->                         -- (d)
           do  z             <- consStmt (envAddGuard xc True gI') body          -- (e)
-              whenJustM z    $ consWhileStep l xs tIs                           -- (f) 
+              whenJustM z    $ consWhileStep l xs tIs                           -- (f)
               return         $ Just $ envAddGuard xc False gI'
     where
         (xs,ts)              = unzip $ [xts | PhiVarTy xts <- ann_fact l]
 
-consWhileBase l xs tIs g    
-  = do  xts_base           <- mapM (\x -> (x,) <$> safeEnvFindTy x g) xs 
+consWhileBase l xs tIs g
+  = do  xts_base           <- mapM (\x -> (x,) <$> safeEnvFindTy x g) xs
         xts_base'          <- zipWithM (\(x,t) t' -> zipTypeUpM g x t t') xts_base tIs    -- (c)
-        zipWithM_ (subType l err g) xts_base' tIs         
-  where 
+        zipWithM_ (subType l err g) xts_base' tIs
+  where
     err                      = errorLiquid' l
 
-consWhileStep l xs tIs gI'' 
-  = do  xts_step           <- mapM (\x -> (x,) <$> safeEnvFindTy x gI'') xs' 
+consWhileStep l xs tIs gI''
+  = do  xts_step           <- mapM (\x -> (x,) <$> safeEnvFindTy x gI'') xs'
         xts_step'          <- zipWithM (\(x,t) t' -> zipTypeUpM gI'' x t t') xts_step tIs'
         zipWithM_ (subType l err gI'') xts_step' tIs'                           -- (f)
-  where 
+  where
     tIs'                    = F.subst su <$> tIs
     xs'                     = mkNextId   <$> xs
     su                      = F.mkSubst   $  safeZip "consWhileStep" (F.symbol <$> xs) (F.eVar <$> xs')
@@ -1116,7 +1127,7 @@ envJoin :: AnnTypeR -> CGEnv -> Maybe CGEnv -> Maybe CGEnv -> CGM (Maybe CGEnv)
 ----------------------------------------------------------------------------------
 envJoin _ _ Nothing x           = return x
 envJoin _ _ x Nothing           = return x
-envJoin l g (Just g1) (Just g2) = Just <$> envJoin' l g g1 g2 
+envJoin l g (Just g1) (Just g2) = Just <$> envJoin' l g g1 g2
 
 ----------------------------------------------------------------------------------
 envJoin' :: AnnTypeR -> CGEnv -> CGEnv -> CGEnv -> CGM CGEnv
@@ -1124,8 +1135,8 @@ envJoin' :: AnnTypeR -> CGEnv -> CGEnv -> CGEnv -> CGM CGEnv
 
 -- 1. use @envFindTy@ to get types for the phi-var x in environments g1 AND g2
 --
--- 2. use @freshTyPhis@ to generate fresh types (and an extended environment with 
---    the fresh-type bindings) for all the phi-vars using the unrefined types 
+-- 2. use @freshTyPhis@ to generate fresh types (and an extended environment with
+--    the fresh-type bindings) for all the phi-vars using the unrefined types
 --    from step 1
 --
 -- 3. generate subtyping constraints between the types from step 1 and the fresh
@@ -1133,13 +1144,13 @@ envJoin' :: AnnTypeR -> CGEnv -> CGEnv -> CGEnv -> CGM CGEnv
 --
 -- 4. return the extended environment
 --
-envJoin' l g g1 g2 
-  = do  -- 
+envJoin' l g g1 g2
+  = do  --
         -- LOCALS: as usual
         --
-        g1'       <- envAdds "envJoin-0" (zip xls l1s) g1 
+        g1'       <- envAdds "envJoin-0" (zip xls l1s) g1
         g2'       <- envAdds "envJoin-1" (zip xls l2s) g2
-        -- 
+        --
         -- t1s and t2s should have the same raw type, otherwise they wouldn't
         -- pass TC (we don't need to pad / fix them before joining).
         -- So we can use the raw type from one of the two branches and freshen
@@ -1149,10 +1160,10 @@ envJoin' l g g1 g2
         (g',ls)   <- freshTyPhis' l g xls $ (\(EE a i t) -> EE a i $ toType t) <$> l1s
         l1s'      <- mapM (`safeEnvFindTy` g1') xls
         l2s'      <- mapM (`safeEnvFindTy` g2') xls
-        _         <- zipWithM_ (subType l err g1') l1s' ls 
+        _         <- zipWithM_ (subType l err g1') l1s' ls
         _         <- zipWithM_ (subType l err g2') l2s' ls
-        -- 
-        -- GLOBALS: 
+        --
+        -- GLOBALS:
         --
         let (xgs, gl1s, _) = unzip3 $ globals (zip3 xs t1s t2s)
         (g'',gls) <- freshTyPhis' l g' xgs $ (\(EE a i t) -> EE a i $ toType t) <$> gl1s
@@ -1160,32 +1171,32 @@ envJoin' l g g1 g2
         gl2s'     <- mapM (`safeEnvFindTy` g2') xgs
         _         <- zipWithM_ (subType l err g1') gl1s' gls
         _         <- zipWithM_ (subType l err g2') gl2s' gls
-        -- 
-        -- PARTIALLY UNINITIALIZED        
         --
-        -- let (xps, ps) = unzip $ partial $ zip3 xs t1s t2s        
+        -- PARTIALLY UNINITIALIZED
+        --
+        -- let (xps, ps) = unzip $ partial $ zip3 xs t1s t2s
         -- If the variable was previously uninitialized, it will continue to be
         -- so; we don't have to update the environment in this case.
         return     $ g''
     where
         (t1s, t2s) = unzip $ catMaybes $ getPhiTypes l g1 g2 <$> xs
-        -- t1s : the types of the phi vars in the 1st branch 
-        -- t2s : the types of the phi vars in the 2nd branch 
+        -- t1s : the types of the phi vars in the 1st branch
+        -- t2s : the types of the phi vars in the 2nd branch
         (xls, l1s, l2s) = unzip3 $ locals (zip3 xs t1s t2s)
-        xs    = [ xs | PhiVarTC xs <- ann_fact l] 
-        err   = errorLiquid' l 
+        xs    = [ xs | PhiVarTC xs <- ann_fact l]
+        err   = errorLiquid' l
 
 
-getPhiTypes _ g1 g2 x = 
+getPhiTypes _ g1 g2 x =
   case (envFindTyWithAsgn x g1, envFindTyWithAsgn x g2) of
-    (Just t1, Just t2) -> Just (t1,t2) 
-    (_      , _      ) -> Nothing 
-  
+    (Just t1, Just t2) -> Just (t1,t2)
+    (_      , _      ) -> Nothing
 
-locals  ts = [(x,s1,s2) | (x, s1@(EE WriteLocal _ _), 
+
+locals  ts = [(x,s1,s2) | (x, s1@(EE WriteLocal _ _),
                               s2@(EE WriteLocal _ _)) <- ts ]
 
-globals ts = [(x,s1,s2) | (x, s1@(EE WriteGlobal Initialized _), 
+globals ts = [(x,s1,s2) | (x, s1@(EE WriteGlobal Initialized _),
                               s2@(EE WriteGlobal Initialized _)) <- ts ]
 
 -- partial ts = [(x,s2)    | (x, s2@(_, WriteGlobal, Uninitialized)) <- ts]
@@ -1194,16 +1205,16 @@ globals ts = [(x,s1,s2) | (x, s1@(EE WriteGlobal Initialized _),
 
 errorLiquid' = errorLiquid . srcPos
 
--- traceTypePP l msg act 
+-- traceTypePP l msg act
 --   = act >>= \case
---       Just (x,g) -> 
---           do  t <- safeEnvFindTy x g 
---               return $ Just $ trace (ppshow (srcPos l) ++ 
---                                      " " ++ msg ++ 
---                                      ": " ++ ppshow x ++ 
+--       Just (x,g) ->
+--           do  t <- safeEnvFindTy x g
+--               return $ Just $ trace (ppshow (srcPos l) ++
+--                                      " " ++ msg ++
+--                                      ": " ++ ppshow x ++
 --                                      " :: " ++ ppshow t) (x,g)
---       Nothing ->  return Nothing 
-    
+--       Nothing ->  return Nothing
+
 
 -- Local Variables:
 -- flycheck-disabled-checkers: (haskell-liquid)

--- a/src/Language/Nano/Liquid/Qualifiers.hs
+++ b/src/Language/Nano/Liquid/Qualifiers.hs
@@ -1,7 +1,7 @@
 module Language.Nano.Liquid.Qualifiers (qualifiers) where
 
 import Language.Fixpoint.Errors
-import Language.Fixpoint.Types hiding (quals) 
+import Language.Fixpoint.Types hiding (quals)
 import Language.Nano.Liquid.Types
 import Language.Nano.Env
 import Language.Nano.Errors
@@ -13,7 +13,7 @@ import Data.Maybe               (fromMaybe)
 
 -- nanoQualifiers   :: NanoRefType -> [Qualifier]
 -- nanoQualifiers p  = pQuals p ++ nanoQualifiers' p
--- 
+--
 -- nanoQualifiers'  :: NanoRefType -> [Qualifier]
 -- nanoQualifiers' p = concatMap (refTypeQualifiers γ0) $ envToList env
 --   where
@@ -26,28 +26,27 @@ qualifiers xts = concatMap (refTypeQualifiers γ0) xts
 
 
 
-refTypeQualifiers γ0 (l, t) = efoldRType rTypeSort addQs γ0 [] t 
+refTypeQualifiers γ0 (l, t) = efoldRType rTypeSort addQs γ0 [] t
   where
     addQs γ t qs  = mkQuals l γ t ++ qs
 
-mkQuals l γ t     = [ mkQual l γ v so pa | let (RR so (Reft (v, ras))) = rTypeSortedReft t 
-                                         , RConc p                    <- ras                 
-                                         , pa                         <- atoms p
+mkQuals l γ t     = [ mkQual l γ v so pa | let (RR so (Reft (v, ra))) = rTypeSortedReft t
+                                         , pa                        <- conjuncts $ raPred ra
                     ]
 
-mkQual l γ v so p = Q (symbol "Auto") ((v, so) : yts) (subst θ p) l0 
-  where 
+mkQual l γ v so p = Q (symbol "Auto") ((v, so) : yts) (subst θ p) l0
+  where
     yts           = [(y, lookupSort l x γ) | (x, y) <- xys ]
     θ             = mkSubst [(x, eVar y)   | (x, y) <- xys]
-    xys           = zipWith (\x i -> (x, symbol ("~A" ++ show i))) xs [0..] 
+    xys           = zipWith (\x i -> (x, symbol ("~A" ++ show i))) xs [0..]
     xs            = delete v $ orderedFreeVars γ p
     l0            = dummyPos "RSC.Qualifiers.mkQual"
 
-lookupSort l  x γ = fromMaybe err $ lookupSEnv x γ 
-  where 
+lookupSort l  x γ = fromMaybe err $ lookupSEnv x γ
+  where
     err           = die $ bug (srcPos l) $ "Unbound variable " ++ show x ++ " in specification for " ++ show (unId l)
 
-orderedFreeVars γ = nub . filter (`memberSEnv` γ) . syms 
+orderedFreeVars γ = nub . filter (`memberSEnv` γ) . syms
 
 atoms (PAnd ps)   = concatMap atoms ps
 atoms p           = [p]

--- a/src/Language/Nano/Liquid/Qualifiers.hs
+++ b/src/Language/Nano/Liquid/Qualifiers.hs
@@ -24,8 +24,6 @@ qualifiers xts = concatMap (refTypeQualifiers γ0) xts
   where
      γ0        = envSEnv $ envMap rTypeSort $ envFromList xts
 
-
-
 refTypeQualifiers γ0 (l, t) = efoldRType rTypeSort addQs γ0 [] t
   where
     addQs γ t qs  = mkQuals l γ t ++ qs
@@ -48,5 +46,3 @@ lookupSort l  x γ = fromMaybe err $ lookupSEnv x γ
 
 orderedFreeVars γ = nub . filter (`memberSEnv` γ) . syms
 
-atoms (PAnd ps)   = concatMap atoms ps
-atoms p           = [p]

--- a/src/Language/Nano/Liquid/Types.hs
+++ b/src/Language/Nano/Liquid/Types.hs
@@ -290,14 +290,14 @@ rTypeSortApp TFPBool _             = F.boolSort
 rTypeSortApp TString _             = F.strSort
 rTypeSortApp c ts                  = F.FApp (tconFTycon c) (rTypeSort <$> ts)
 
-
+-- RJ: why are these suddenly uppercase?
 tconFTycon :: TCon -> F.FTycon
-tconFTycon TBool                   = rawStringFTycon "Boolean"
-tconFTycon TVoid                   = rawStringFTycon "Void"
-tconFTycon TUn                     = rawStringFTycon "Union"
-tconFTycon TTop                    = rawStringFTycon "Top"
-tconFTycon TNull                   = rawStringFTycon "Null"
-tconFTycon TUndef                  = rawStringFTycon "Undefined"
+tconFTycon TBool                   = rawStringFTycon "boolean"
+tconFTycon TVoid                   = rawStringFTycon "void"
+tconFTycon TUn                     = rawStringFTycon "union"
+tconFTycon TTop                    = rawStringFTycon "top"
+tconFTycon TNull                   = rawStringFTycon "null"
+tconFTycon TUndef                  = rawStringFTycon "undefined"
 tconFTycon c                       = error $ "impossible: tconFTycon " ++ show c
 
 rTypeSortForAll t                  = genSort n θ $ rTypeSort tbody

--- a/src/Language/Nano/Liquid/Types.hs
+++ b/src/Language/Nano/Liquid/Types.hs
@@ -11,10 +11,10 @@
 -- | Module pertaining to Refinement Type descriptions and conversions
 --   Likely mergeable with @Language.Nano.Typecheck.Types@
 
-module Language.Nano.Liquid.Types ( 
-  
+module Language.Nano.Liquid.Types (
+
   -- * Refinement Types
-    RefType 
+    RefType
 
   -- * Constraint Environments
   , CGEnvR(..), CGEnv
@@ -30,19 +30,19 @@ module Language.Nano.Liquid.Types (
 
   -- * Conversions
   , RefTypable (..), eSingleton, pSingleton
-  
+
   -- * Manipulating RefType
   , rTypeReft, rTypeSort, rTypeSortedReft, rTypeValueVar
 
   -- * Manipulating Reft
   , noKVars
 
-  -- * Predicates On RefType 
+  -- * Predicates On RefType
   , isTrivialRefType
 
   -- * Useful Operations
   , foldReft, efoldRType, emapReft, mapReftM
-  
+
   -- * Annotations
   , AnnTypeR
 
@@ -52,7 +52,7 @@ module Language.Nano.Liquid.Types (
     -- ,  returnSymbol, returnId, symbolId, mkId
 
   -- * Raw low-level Location-less constructors
-  , rawStringSymbol 
+  , rawStringSymbol
 
   -- * Zip types
   , zipType
@@ -70,8 +70,8 @@ import qualified Data.Map.Strict         as M
 import           Data.Monoid                        (mconcat)
 import qualified Data.Traversable        as T
 import           Text.PrettyPrint.HughesPJ
-import           Text.Printf 
-import           Control.Applicative 
+import           Text.Printf
+import           Control.Applicative
 import           Control.Monad          (zipWithM)
 
 import           Language.Nano.Syntax
@@ -96,7 +96,7 @@ import qualified Language.Fixpoint.Types as F
 import           Language.Fixpoint.PrettyPrint
 import           Language.Fixpoint.Errors
 import qualified Language.Fixpoint.Visitor as V
-  
+
 -- import           Debug.Trace                        (trace)
 
 -------------------------------------------------------------------------------------
@@ -107,32 +107,32 @@ type RefType     = RType F.Reft
 type AnnTypeR    = AnnType F.Reft
 
 ----------------------------------------------------------------------------
--- | Constraint Information 
+-- | Constraint Information
 ----------------------------------------------------------------------------
 
 data Cinfo = Ci { ci_info    :: !Error
                 , ci_srcspan :: !SrcSpan
-                } deriving (Eq, Ord, Show) 
+                } deriving (Eq, Ord, Show)
 
 ci   :: (IsLocated a) => Error -> a -> Cinfo
-ci e = Ci e . srcPos 
+ci e = Ci e . srcPos
 
 instance PP Cinfo where
   pp (Ci e l)   = text "CInfo:" <+> pp l <+> (parens $ pp e)
-  
-instance IsLocated Cinfo where
-  srcPos = ci_srcspan 
 
-instance F.Fixpoint Cinfo where 
+instance IsLocated Cinfo where
+  srcPos = ci_srcspan
+
+instance F.Fixpoint Cinfo where
   toFix = pp
 
 ----------------------------------------------------------------------------
--- | Constraints 
+-- | Constraints
 ----------------------------------------------------------------------------
 
 -- | Subtyping Constraints
 
-data SubC     
+data SubC
   = Sub { senv  :: !CGEnv      -- ^ Environment
         , sinfo :: !Cinfo      -- ^ Source Information
         , slhs  :: !RefType    -- ^ Subtyping LHS
@@ -141,24 +141,24 @@ data SubC
 
 -- | Wellformedness Constraints
 
-data WfC 
+data WfC
   = W { wenv  :: !CGEnv      -- ^ Scope/Environment
       , winfo :: !Cinfo      -- ^ Source Information
       , wtyp  :: !RefType    -- ^ Type to be Well-formed ... wenv |- wtyp
       }
 
-instance PP F.Reft where 
+instance PP F.Reft where
   pp = pprint
 
 instance PP SubC where
-  pp (Sub γ i t t') = pp (cge_names γ) $+$ pp (cge_guards γ) 
+  pp (Sub γ i t t') = pp (cge_names γ) $+$ pp (cge_guards γ)
                         $+$ ((text "|-") <+> (pp t $+$ text "<:" $+$ pp t'))
-                        $+$ ((text "from:") <+> pp i) 
+                        $+$ ((text "from:") <+> pp i)
 
 instance PP WfC where
-  pp (W γ t i)      = pp (cge_names γ) 
-                        $+$ (text "|-" <+> pp t) 
-                        $+$ ((text "from:") <+> pp i) 
+  pp (W γ t i)      = pp (cge_names γ)
+                        $+$ (text "|-" <+> pp t)
+                        $+$ ((text "from:") <+> pp i)
 
 instance IsLocated SubC where
   srcPos = srcPos . sinfo
@@ -173,7 +173,7 @@ type FixWfC  = F.WfC  Cinfo
 
 
 ------------------------------------------------------------------
--- | Converting `Nano` values into `Fixpoint` values, 
+-- | Converting `Nano` values into `Fixpoint` values,
 --   i.e. *language* level entities into *logic* level entities.
 ------------------------------------------------------------------
 
@@ -187,32 +187,32 @@ instance F.Expression (Expression a) where
   expr (IntLit _ i)                 = F.expr i
   expr (VarRef _ x)                 = F.expr x
   expr (InfixExpr _ o e1 e2)        = F.EBin (bop o) (F.expr e1) (F.expr e2)
-  expr (PrefixExpr _ PrefixMinus e) = F.EBin F.Minus (F.expr (0 :: Int)) (F.expr e)  
+  expr (PrefixExpr _ PrefixMinus e) = F.EBin F.Minus (F.expr (0 :: Int)) (F.expr e)
   expr (Cast_ _ e)                  = F.expr e
   expr (Cast  _ e)                  = F.expr e
   expr e                            = convertError "F.Expr" e
 
-instance F.Predicate  (Expression a) where 
+instance F.Predicate  (Expression a) where
   prop (BoolLit _ True)            = F.PTrue
   prop (BoolLit _ False)           = F.PFalse
   prop (PrefixExpr _ PrefixLNot e) = F.PNot (F.prop e)
   prop e@(InfixExpr _ _ _ _ )      = eProp e
-  prop e                           = convertError "F.Pred" e  
+  prop e                           = convertError "F.Pred" e
 
 
 ------------------------------------------------------------------
 eProp :: Expression a -> F.Pred
 ------------------------------------------------------------------
 
-eProp (InfixExpr _ OpLT   e1 e2)       = F.PAtom F.Lt (F.expr e1) (F.expr e2) 
-eProp (InfixExpr _ OpLEq  e1 e2)       = F.PAtom F.Le (F.expr e1) (F.expr e2) 
-eProp (InfixExpr _ OpGT   e1 e2)       = F.PAtom F.Gt (F.expr e1) (F.expr e2)  
-eProp (InfixExpr _ OpGEq  e1 e2)       = F.PAtom F.Ge (F.expr e1) (F.expr e2)  
--- FIXME: 
--- eProp (InfixExpr _ OpEq   e1 e2)       = F.PAtom F.Eq (F.expr e1) (F.expr e2) 
-eProp (InfixExpr _ OpStrictEq   e1 e2) = F.PAtom F.Eq (F.expr e1) (F.expr e2) 
-eProp (InfixExpr _ OpNEq  e1 e2)       = F.PAtom F.Ne (F.expr e1) (F.expr e2) 
-eProp (InfixExpr _ OpLAnd e1 e2)       = pAnd (F.prop e1) (F.prop e2) 
+eProp (InfixExpr _ OpLT   e1 e2)       = F.PAtom F.Lt (F.expr e1) (F.expr e2)
+eProp (InfixExpr _ OpLEq  e1 e2)       = F.PAtom F.Le (F.expr e1) (F.expr e2)
+eProp (InfixExpr _ OpGT   e1 e2)       = F.PAtom F.Gt (F.expr e1) (F.expr e2)
+eProp (InfixExpr _ OpGEq  e1 e2)       = F.PAtom F.Ge (F.expr e1) (F.expr e2)
+-- FIXME:
+-- eProp (InfixExpr _ OpEq   e1 e2)       = F.PAtom F.Eq (F.expr e1) (F.expr e2)
+eProp (InfixExpr _ OpStrictEq   e1 e2) = F.PAtom F.Eq (F.expr e1) (F.expr e2)
+eProp (InfixExpr _ OpNEq  e1 e2)       = F.PAtom F.Ne (F.expr e1) (F.expr e2)
+eProp (InfixExpr _ OpLAnd e1 e2)       = pAnd (F.prop e1) (F.prop e2)
 eProp (InfixExpr _ OpLOr  e1 e2)       = pOr  (F.prop e1) (F.prop e2)
 eProp e                                = convertError "InfixExpr -> F.Prop" e
 
@@ -220,7 +220,7 @@ eProp e                                = convertError "InfixExpr -> F.Prop" e
 bop       :: InfixOp -> F.Bop
 ------------------------------------------------------------------
 
-bop OpSub = F.Minus 
+bop OpSub = F.Minus
 bop OpAdd = F.Plus
 bop OpMul = F.Times
 bop OpDiv = F.Div
@@ -228,7 +228,7 @@ bop OpMod = F.Mod
 bop o     = convertError "F.Bop" o
 
 ------------------------------------------------------------------
-pAnd p q  = F.pAnd [p, q] 
+pAnd p q  = F.pAnd [p, q]
 pOr  p q  = F.pOr  [p, q]
 
 
@@ -238,7 +238,7 @@ pOr  p q  = F.pOr  [p, q]
 ------------------------------------------------------------------------
 
 class RefTypable a where
-  rType :: a -> RefType 
+  rType :: a -> RefType
 
 instance RefTypable Type where
   rType = ofType
@@ -246,11 +246,11 @@ instance RefTypable Type where
 instance RefTypable RefType where
   rType = ofType . toType           -- removes all refinements
 
-eSingleton      :: (F.Expression e) => RefType -> e -> RefType 
+eSingleton      :: (F.Expression e) => RefType -> e -> RefType
 eSingleton t e  = t `strengthen` (F.uexprReft e)
 
 
-pSingleton      :: (F.Predicate p) => RefType -> p -> RefType 
+pSingleton      :: (F.Predicate p) => RefType -> p -> RefType
 pSingleton t p  = t `strengthen` (F.propReft p)
 
 ------------------------------------------------------------------------------
@@ -261,20 +261,20 @@ rTypeSortedReft   ::  PPR r => RTypeQ q r -> F.SortedReft
 rTypeSortedReft t = F.RR (rTypeSort t) (rTypeReft t)
 
 rTypeReft         :: (F.Reftable r) => RTypeQ q r -> F.Reft
-rTypeReft         = fromMaybe fTop . fmap F.toReft . stripRTypeBase 
+rTypeReft         = fromMaybe fTop . fmap F.toReft . stripRTypeBase
 
 rTypeValueVar     :: (F.Reftable r) => RTypeQ q r -> F.Symbol
-rTypeValueVar t   = vv where F.Reft (vv,_) = rTypeReft t 
+rTypeValueVar t   = vv where F.Reft (vv,_) = rTypeReft t
 
 ------------------------------------------------------------------------------------------
 rTypeSort :: (PPR r) => RTypeQ q r -> F.Sort
 ------------------------------------------------------------------------------------------
-rTypeSort (TVar α _)               = F.FObj $ F.symbol α 
+rTypeSort (TVar α _)               = F.FObj $ F.symbol α
 rTypeSort (TAll v t)               = rTypeSortForAll $ TAll v t
 rTypeSort (TFun (Just s) xts t _)  = F.FFunc 0 $ rTypeSort <$> [s] ++ (b_type <$> xts) ++ [t]
 rTypeSort (TFun Nothing  xts t _)  = F.FFunc 0 $ rTypeSort <$> (b_type <$> xts) ++ [t]
 rTypeSort (TApp TBV32 _ _ )        = BV.mkSort BV.S32
-rTypeSort (TApp c ts _)            = rTypeSortApp c ts 
+rTypeSort (TApp c ts _)            = rTypeSortApp c ts
 rTypeSort (TAnd (t:_))             = rTypeSort t
 rTypeSort (TRef (QN _ _ _ s) ts _) = F.FApp (rawStringFTycon $ F.symbolString s) (rTypeSort <$> ts)
 rTypeSort (TCons _ _ _ )           = F.FApp (rawStringFTycon $ F.symbol "Object") []
@@ -286,9 +286,9 @@ rTypeSort t                        = error $ render $ text "BUG: rTypeSort does 
 
 rTypeSortApp TInt _                = F.FInt
 rTypeSortApp TUn  _                = F.FApp (tconFTycon TUn) []
-rTypeSortApp c ts                  = F.FApp (tconFTycon c) (rTypeSort <$> ts) 
+rTypeSortApp c ts                  = F.FApp (tconFTycon c) (rTypeSort <$> ts)
 
-tconFTycon :: TCon -> F.FTycon 
+tconFTycon :: TCon -> F.FTycon
 tconFTycon TInt                    = F.intFTyCon
 tconFTycon TBV32                   = error "tconFTycon should be unreachable for BV32" -- BV.mkSort BV.S32 -- BV.bvTyCon
 tconFTycon TBool                   = rawStringFTycon "Boolean"
@@ -302,16 +302,16 @@ tconFTycon TUndef                  = rawStringFTycon "Undefined"
 
 
 rTypeSortForAll t    = genSort n θ $ rTypeSort tbody
-  where 
+  where
     (αs, tbody)      = bkAll t
     n                = length αs
     θ                = HM.fromList $ zip (F.symbol <$> αs) (F.FVar <$> [0..])
-    
+
 genSort n θ (F.FFunc _ t)  = F.FFunc n (F.sortSubst θ <$> t)
 genSort n θ t              = F.FFunc n [F.sortSubst θ t]
 
 ------------------------------------------------------------------------------------------
-stripRTypeBase :: RTypeQ q r -> Maybe r 
+stripRTypeBase :: RTypeQ q r -> Maybe r
 ------------------------------------------------------------------------------------------
 stripRTypeBase (TApp _ _ r)   = Just r
 stripRTypeBase (TRef _ _ r)   = Just r
@@ -323,21 +323,27 @@ stripRTypeBase _              = Nothing
 ------------------------------------------------------------------------------------------
 noKVars :: F.Reft -> F.Reft
 ------------------------------------------------------------------------------------------
-noKVars (F.Reft (s,ras)) = F.Reft (s, [ c | c@(F.RConc _) <- ras ])
+noKVars (F.Reft (x, F.Refa p)) = F.Reft (x, F.Refa $ dropKs p)
+  where
+    dropKs                     = F.pAnd . filter (not . isK) . F.conjuncts
+    isK (F.PKVar {})           = True
+    isK _                      = False
+
+
 
 ------------------------------------------------------------------------------------------
 -- | Substitutions
 ------------------------------------------------------------------------------------------
 
 instance (PPR r, F.Subable r) => F.Subable (RTypeQ q r) where
-  syms        = foldReft (\r acc -> F.syms r ++ acc) [] 
-  substa      = fmap . F.substa 
-  substf f    = emapReft (F.substf . F.substfExcept f) [] 
+  syms        = foldReft (\r acc -> F.syms r ++ acc) []
+  substa      = fmap . F.substa
+  substf f    = emapReft (F.substf . F.substfExcept f) []
   subst su    = emapReft (F.subst  . F.substExcept su) []
   subst1 t su = emapReft (\xs r -> F.subst1Except xs r su) [] t
 
 ------------------------------------------------------------------------------------------
--- | Traversals over @RType@ 
+-- | Traversals over @RType@
 ------------------------------------------------------------------------------------------
 
 ------------------------------------------------------------------------------------------
@@ -348,7 +354,7 @@ emapReft f γ (TApp c ts r)     = TApp c (emapReft f γ <$> ts) (f γ r)
 emapReft f γ (TRef c ts r)     = TRef c (emapReft f γ <$> ts) (f γ r)
 emapReft f γ (TSelf m )        = TSelf  (emapReft f γ m)
 emapReft f γ (TAll α t)        = TAll α (emapReft f γ t)
-emapReft f γ (TFun s xts t r)  = TFun (emapReft f γ' <$> s) (emapReftBind f γ' <$> xts) 
+emapReft f γ (TFun s xts t r)  = TFun (emapReft f γ' <$> s) (emapReftBind f γ' <$> xts)
                                       (emapReft f γ' t) (f γ r) where γ' = (b_sym <$> xts) ++ γ
 emapReft f γ (TCons m xts r)   = TCons m (M.map (emapReftElt f γ) xts) (f γ r)
 emapReft _ _ (TClass c)        = TClass c
@@ -369,11 +375,11 @@ mapReftM f (TVar α r)          = TVar α  <$> f r
 mapReftM f (TApp c ts r)       = TApp c  <$> mapM (mapReftM f) ts <*> f r
 mapReftM f (TRef c ts r)       = TRef c  <$> mapM (mapReftM f) ts <*> f r
 mapReftM f (TSelf m)           = TSelf   <$> mapReftM f m
-mapReftM f (TFun s xts t r)    = TFun    <$> T.mapM (mapReftM f) s 
-                                         <*> mapM (mapReftBindM f) xts 
-                                         <*> mapReftM f t 
+mapReftM f (TFun s xts t r)    = TFun    <$> T.mapM (mapReftM f) s
+                                         <*> mapM (mapReftBindM f) xts
+                                         <*> mapReftM f t
                                          <*> f r
-                                         -- XXX : What is this about ??? 
+                                         -- XXX : What is this about ???
                                          -- <*> return (F.top r)
 mapReftM f (TAll α t)          = TAll α  <$> mapReftM f t
 mapReftM f (TAnd ts)           = TAnd    <$> mapM (mapReftM f) ts
@@ -381,7 +387,7 @@ mapReftM f (TCons m bs r)      = TCons m <$> T.mapM (mapReftEltM f) bs <*> f r
 mapReftM _ (TClass a)          = return   $ TClass a
 mapReftM _ (TModule a)         = return   $ TModule a
 mapReftM _ (TEnum a)           = return   $ TEnum a
-mapReftM _ t                   = error    $ render $ text "Not supported in mapReftM: " <+> pp t 
+mapReftM _ t                   = error    $ render $ text "Not supported in mapReftM: " <+> pp t
 
 mapReftBindM f (B x t)         = B x     <$> mapReftM f t
 
@@ -393,28 +399,28 @@ mapReftEltM f (IndexSig x b t)   = IndexSig x b   <$> mapReftM f t
 
 
 ------------------------------------------------------------------------------------------
--- | fold over @RType@ 
+-- | fold over @RType@
 ------------------------------------------------------------------------------------------
 
 ------------------------------------------------------------------------------------------
 foldReft  :: PPR r => (r -> a -> a) -> a -> RTypeQ q r -> a
 ------------------------------------------------------------------------------------------
-foldReft  f = efoldReft (\_ -> ()) (\_ -> f) F.emptySEnv 
+foldReft  f = efoldReft (\_ -> ()) (\_ -> f) F.emptySEnv
 
 ------------------------------------------------------------------------------------------
-efoldReft :: PPR r => (RTypeQ q r -> b) -> (F.SEnv b -> r -> a -> a) 
+efoldReft :: PPR r => (RTypeQ q r -> b) -> (F.SEnv b -> r -> a -> a)
                    -> F.SEnv b -> a -> RTypeQ q r -> a
 ------------------------------------------------------------------------------------------
-efoldReft g f = go 
-  where 
+efoldReft g f = go
+  where
     go γ z (TVar _ r)       = f γ r z
     go γ z t@(TApp _ ts r)  = f γ r $ gos (efoldExt g (B (rTypeValueVar t) t) γ) z ts
     go γ z t@(TRef _ ts r)  = f γ r $ gos (efoldExt g (B (rTypeValueVar t) t) γ) z ts
     go γ z (TSelf m)        = go γ z m
     go γ z (TAll _ t)       = go γ z t
-    go γ z (TFun s xts t r) = f γ r $ go γ' (gos γ' z (maybeToList s ++ map b_type xts)) t  
+    go γ z (TFun s xts t r) = f γ r $ go γ' (gos γ' z (maybeToList s ++ map b_type xts)) t
                                 where γ' = foldr (efoldExt g) γ xts
-    go γ z (TAnd ts)        = gos γ z ts 
+    go γ z (TAnd ts)        = gos γ z ts
     go γ z (TCons _ bs r)   = f γ' r $ gos γ' z (f_type <$> M.elems bs)
                                 -- PV: using the offset(x,"f") at the moment
                                 where γ' = foldr (efoldExt' g) γ $ M.elems bs
@@ -427,15 +433,15 @@ efoldReft g f = go
 
 efoldExt g xt γ             = F.insertSEnv (b_sym xt) (g $ b_type xt) γ
 
--- The only type members that can appear in refinements are immutable fields 
-efoldExt' g (FieldSig f _ m t) γ 
-  | isImmutable m 
+-- The only type members that can appear in refinements are immutable fields
+efoldExt' g (FieldSig f _ m t) γ
+  | isImmutable m
   = F.insertSEnv (F.qualifySymbol (F.symbol $ builtinOpId BIThis) f) (g t) γ
 efoldExt' _ _ γ = γ
 
 ------------------------------------------------------------------------------------------
-efoldRType :: PPR r 
-           => (RTypeQ q r -> b) -> (F.SEnv b -> RTypeQ q r -> a -> a) 
+efoldRType :: PPR r
+           => (RTypeQ q r -> b) -> (F.SEnv b -> RTypeQ q r -> a -> a)
            -> F.SEnv b -> a -> RTypeQ q r -> a
 ------------------------------------------------------------------------------------------
 efoldRType g f                 = go
@@ -448,10 +454,10 @@ efoldRType g f                 = go
     go γ z t@(TFun s xts t1 _) = f γ t $ go γ' (gos γ' z (maybeToList s ++ map b_type xts)) t1
                                    where γ' = foldr (efoldExt g) γ $ maybeToList thisBOpt ++ xts
                                          thisBOpt = (B $ F.symbol $ builtinOpId BIThis) <$> s
-                                          
-    go γ z   (TAnd ts)         = gos γ z ts 
 
-    go γ z t@(TCons _ bs _ )   = f γ' t $ gos γ' z (f_type <$> M.elems bs) 
+    go γ z   (TAnd ts)         = gos γ z ts
+
+    go γ z t@(TCons _ bs _ )   = f γ' t $ gos γ' z (f_type <$> M.elems bs)
                                    where γ' = M.foldr (efoldExt' g) γ bs
 
     go γ z t@(TClass _)        = f γ t z
@@ -470,40 +476,47 @@ isTrivialRefType :: RefType -> Bool
 isTrivialRefType (TFun a b c _) = isTrivialRefType' (TFun a b c fTop)
 isTrivialRefType t              = isTrivialRefType' t
 
-isTrivialRefType' t     = foldReft (\r -> (f r &&)) True t
-  where 
-    f (F.Reft (_,ras)) = null ras
+isTrivialRefType' :: RefType -> Bool
+isTrivialRefType' = foldReft (\r -> (f r &&)) True
+  where
+    f :: F.Reft -> Bool
+    f = F.isTauto -- (F.Reft (_,ras)) = null ras
 
-rawStringSymbol = F.Loc (F.dummyPos "RSC.Types.rawStringSymbol") . F.symbol
-rawStringFTycon = F.symbolFTycon . F.Loc (F.dummyPos "RSC.Types.rawStringFTycon") . F.symbol
+rawStringSymbol = F.locAt "RSC.Types.rawStringSymbol"
+                . F.symbol
+
+rawStringFTycon = F.symbolFTycon
+                . F.locAt "RSC.Types.rawStringFTycon"
+                . F.symbol
+
 
 
 -----------------------------------------------------------------------------------
--- | Helpers for extracting specifications from @Nano@ @Statement@ 
+-- | Helpers for extracting specifications from @Nano@ @Statement@
 -----------------------------------------------------------------------------------
 
-getInvariant :: Statement a -> F.Pred 
+getInvariant :: Statement a -> F.Pred
 
 getInvariant = getSpec getInv . flattenStmt
 
-getAssume    :: Statement a -> Maybe F.Pred 
+getAssume    :: Statement a -> Maybe F.Pred
 getAssume    = getStatementPred "assume"
 
-getAssert    :: Statement a -> Maybe F.Pred 
+getAssert    :: Statement a -> Maybe F.Pred
 getAssert    = getStatementPred "assert"
 
 getRequires  = getStatementPred "requires"
 getEnsures   = getStatementPred "ensures"
 getInv       = getStatementPred "invariant"
 
-getStatementPred :: String -> Statement a -> Maybe F.Pred 
+getStatementPred :: String -> Statement a -> Maybe F.Pred
 getStatementPred name (ExprStmt _ (CallExpr _ (VarRef _ (Id _ f)) [p]))
-  | name == f 
+  | name == f
   = Just $ F.prop p
-getStatementPred _ _ 
-  = Nothing 
+getStatementPred _ _
+  = Nothing
 
-getSpec   :: (Statement a -> Maybe F.Pred) -> [Statement a] -> F.Pred 
+getSpec   :: (Statement a -> Maybe F.Pred) -> [Statement a] -> F.Pred
 getSpec g = mconcat . catMaybes . map g
 
 getFunctionIds :: Statement a -> [Id a]
@@ -517,7 +530,7 @@ getFunctionIds s = [f | (FunctionStmt _ f _ _) <- flattenStmt s]
 --  * structurally equivalent to @t2@
 --
 --------------------------------------------------------------------------------
-zipType :: (F.Symbolic x, IsLocated x) 
+zipType :: (F.Symbolic x, IsLocated x)
         => CGEnv -> x -> RefType -> RefType -> Maybe (F.Reft -> RefType, F.Reft)
 --------------------------------------------------------------------------------
 --
@@ -525,7 +538,7 @@ zipType :: (F.Symbolic x, IsLocated x)
 --
 zipType _ _ _ t2                 | isTop t2 = return (setRTypeR t2, fTop)
 
--- 
+--
 -- Unions
 --
 zipType γ _ (TApp TUn t1s r1) (TApp TUn t2s _)
@@ -547,28 +560,28 @@ zipType _ _ (TSelf _) (TSelf m2) = return (\_ -> TSelf m2, fTop)
 -- No unions below this point
 --
 -- Class/interface types
--- 
+--
 --   C<Vi> extends C'<Wi>
 --   --------------------------------
 --   C<Si> || C'<Ti> = C'<Wi[Vi/Si]>
---   
+--
 --   C </: C'
 --   ------------------------------------------------------
 --   C<Si> || C'<Ti> = toStruct(C<Si>) || toStruct(C<Ti>)
---   
---   
+--
+--
 --   C<Si> || {F;M} = toStruct(C<Si>) || {F;M}
---   
-zipType γ x t1@(TRef x1 (m1:t1s) r1) t2@(TRef x2 (m2:t2s) _) 
+--
+zipType γ x t1@(TRef x1 (m1:t1s) r1) t2@(TRef x2 (m2:t2s) _)
   | x1 == x2
   = do  ts    <- zipWithM (\t t' -> appZ <$> zipType γ x t t') t1s t2s
         return $ (TRef x2 (m2:ts), r1)
-  -- 
+  --
   --    t1 <: t2
   --
-  | Just (_, m1':t1s') <- weaken γ (x1,m1:t1s) x2 
+  | Just (_, m1':t1s') <- weaken γ (x1,m1:t1s) x2
   = zipType γ x (TRef x2 (m1':t1s') r1 `strengthen` rtExt t1 (F.symbol x1)) t2
-  -- 
+  --
   --    t2 <: t1
   --
   --    Only support this limited case with NO type arguments
@@ -579,31 +592,31 @@ zipType γ x t1@(TRef x1 (m1:t1s) r1) t2@(TRef x2 (m2:t2s) _)
   -- DO NOT UNFOLD TO STRUCTURES
   --
   -- DANGER OF INFINITE LOOPS BECAUSE OF RECURSIVE TYPES
-  -- 
+  --
   where
-    rtExt t c  = F.Reft (vv t, [raExt t c])
-    raExt t c  = F.RConc $ F.PBexp $ F.EApp (sym t) 
-               $ [F.expr $ vv t, F.expr $ F.symbolText c]
-    vv         = rTypeValueVar
-    sym t      | isClassType γ t = extClassSym
-               | otherwise       = extInterfaceSym
+    rtExt t c           = F.reft (vv t) (raExt t c)
+    raExt t c           = F.PBexp $ F.EApp (sym t) [F.expr $ vv t, F.expr $ F.symbolText c]
+    vv                  = rTypeValueVar
+    sym t
+      | isClassType γ t = F.dummyLoc $ F.symbol "extends_class"
+      | otherwise       = F.dummyLoc $ F.symbol "extends_interface"
 
 zipType _ _ t1@(TRef _ [] _) _ = error $ "zipType on " ++ ppshow t1  -- Invalid type
 zipType _ _ _ t2@(TRef _ [] _) = error $ "zipType on " ++ ppshow t2  -- Invalid type
 
 zipType γ x t1@(TRef _ _ _) t2 = do t1' <- expandTypeWithSub γ x t1
-                                    t2' <- expandTypeWithSub γ x t2 
+                                    t2' <- expandTypeWithSub γ x t2
                                     zipType γ x t1' t2'
 
-zipType γ x t1 t2@(TRef _ _ _) = do t1' <- expandTypeWithSub γ x t1 
-                                    t2' <- expandTypeWithSub γ x t2 
+zipType γ x t1 t2@(TRef _ _ _) = do t1' <- expandTypeWithSub γ x t1
+                                    t2' <- expandTypeWithSub γ x t2
                                     zipType γ x t1' t2'
 
-zipType γ x t1@(TClass x1) t2@(TClass x2) 
+zipType γ x t1@(TClass x1) t2@(TClass x2)
   | x2 `elem` allAncestors γ x1
   = return $ (setRTypeR (TClass x2), fTop)
-  | otherwise 
-  = do  t1' <- expandTypeWithSub γ x t1 
+  | otherwise
+  = do  t1' <- expandTypeWithSub γ x t1
         t2' <- expandTypeWithSub γ x t2
         zipType γ x t1' t2'
 
@@ -616,23 +629,23 @@ zipType γ x t1 t2@(TClass _) = do t2' <- expandTypeWithSub γ x t2
 zipType _ _ (TApp c [] r) (TApp c' [] _) | c == c'  = return (TApp c [], r)
 
 zipType _ _ (TVar v r) (TVar v' _)       | v == v'  = return (TVar v, r)
--- 
+--
 -- Function types
 --
 -- (Si) => S # (Ti) => T  =  (Si#Ti) => S#T
 --
--- * Keep the LHS binders as they might appear in the 
+-- * Keep the LHS binders as they might appear in the
 --   refinements which will belong to the LHS
 --
 zipType γ x (TFun (Just s1) x1s t1 r1) (TFun (Just s2) x2s t2 _) = do
   s   <- appZ <$> zipType γ x s1 s2
-  xs  <- zipWithM (zipBind γ x) x1s x2s 
-  t   <- appZ <$> zipType γ x t1 t2 
+  xs  <- zipWithM (zipBind γ x) x1s x2s
+  t   <- appZ <$> zipType γ x t1 t2
   return (TFun (Just s) xs t, r1)
- 
-zipType γ x (TFun Nothing x1s t1 r1) (TFun Nothing x2s t2 _) = do 
-  xs  <- zipWithM (zipBind γ x) x1s x2s 
-  t   <- appZ <$> zipType γ x t1 t2 
+
+zipType γ x (TFun Nothing x1s t1 r1) (TFun Nothing x2s t2 _) = do
+  xs  <- zipWithM (zipBind γ x) x1s x2s
+  t   <- appZ <$> zipType γ x t1 t2
   return (TFun Nothing xs t, r1)
 
 zipType _ _ (TFun _ _ _ _ ) (TFun _ _ _ _) = Nothing
@@ -641,55 +654,55 @@ zipType _ _ (TFun _ _ _ _ ) (TFun _ _ _ _) = Nothing
 --
 -- { F1,F2 } | { F1',F3' } = { F1|F1',top(F3) }, where disjoint F2 F3'
 --
-zipType γ x (TCons _ e1s r1) (TCons m2 e2s _) = do 
+zipType γ x (TCons _ e1s r1) (TCons m2 e2s _) = do
     common'            <- T.mapM (uncurry $ zipElts γ x) common
     return              $ (TCons m2 (common' `M.union` disjoint'), r1)
-  where 
+  where
     common              = M.intersectionWith (,) e1s e2s
     disjoint'           = M.map (fmap $ const fTop) $ e2s `M.difference` e1s
--- 
+--
 -- Intersection types
 --
 -- s1 /\ s2 .. /\ sn | t1 /\ t2 .. tm = s1'|t1' /\ .. sk'|tk' /\ .. top(tm')
 --
 zipType γ x (TAnd t1s) (TAnd t2s) =
     case [ (pick t2, t2) | t2 <- t2s ] of
-      []              -> error $ "zipType: impossible intersection types" 
+      []              -> error $ "zipType: impossible intersection types"
       [(t1,t2)]       -> zipType γ x t1 t2
       ts              -> do ts' <- mapM (\(t,t') -> appZ <$> zipType γ x t t') ts
                             return (setRTypeR $ TAnd ts', fTop)
   where
     pick t2            = fromCandidates [ t1 | t1 <- t1s, t1 `matches` t2 ]
-    t `matches` t'     = isSubtype γ t t' || isSubtype γ t' t 
+    t `matches` t'     = isSubtype γ t t' || isSubtype γ t' t
 
-    fromCandidates [ ] = die $ bug (srcPos x) 
+    fromCandidates [ ] = die $ bug (srcPos x)
                        $ "zipType: cannot match " ++ ppshow t2s ++ " with any of " ++ ppshow t1s
     fromCandidates [t] = t
-    fromCandidates  _  = die $ bug (srcPos x) 
+    fromCandidates  _  = die $ bug (srcPos x)
                        $ "zipType: multiple matches of " ++ ppshow t2s ++ " with " ++ ppshow t1s
 
 zipType γ x t1 (TAnd t2s) = zipType γ x (TAnd [t1]) (TAnd t2s)
 zipType γ x (TAnd t1s) t2 = zipType γ x (TAnd t1s) (TAnd [t2])
 
 -- FIXME: preserve t1's ref in all occurences of TVar v1 in the LHS
-zipType γ x (TAll v1 t1) (TAll v2 t2) = 
-    (,fTop) . setRTypeR . TAll v1 . appZ <$> zipType γ x t1 (apply θ t2) 
+zipType γ x (TAll v1 t1) (TAll v2 t2) =
+    (,fTop) . setRTypeR . TAll v1 . appZ <$> zipType γ x t1 (apply θ t2)
   where
     θ = fromList [(v2, tVar v1 :: RefType)]
 
-zipType _ x t1 t2 = errorstar $ printf "BUG[zipType] Unsupported:\n\t%s\n\t%s\nand\n\t%s" 
+zipType _ x t1 t2 = errorstar $ printf "BUG[zipType] Unsupported:\n\t%s\n\t%s\nand\n\t%s"
                         (ppshow $ srcPos x) (ppshow t1) (ppshow t2)
 
 
-zipBind γ x (B s1 t1) (B _ t2) = B s1 <$> appZ <$> zipType γ x t1 t2 
+zipBind γ x (B s1 t1) (B _ t2) = B s1 <$> appZ <$> zipType γ x t1 t2
 
 ------------------------------------------------------------------------------------------
-zipElts :: (F.Symbolic x, IsLocated x) 
-        => CGEnv -> x -> TypeMember F.Reft -> TypeMember F.Reft -> Maybe (TypeMember F.Reft) 
+zipElts :: (F.Symbolic x, IsLocated x)
+        => CGEnv -> x -> TypeMember F.Reft -> TypeMember F.Reft -> Maybe (TypeMember F.Reft)
 ------------------------------------------------------------------------------------------
-zipElts γ x (CallSig t1)        (CallSig t2)           = CallSig           <$> appZ <$> zipType γ x t1 t2 
-zipElts γ x (ConsSig t1)        (ConsSig t2)           = ConsSig           <$> appZ <$> zipType γ x t1 t2 
-zipElts γ x (IndexSig _ _ t1)   (IndexSig x2 b2 t2)    = IndexSig x2 b2    <$> appZ <$> zipType γ x t1 t2 
+zipElts γ x (CallSig t1)        (CallSig t2)           = CallSig           <$> appZ <$> zipType γ x t1 t2
+zipElts γ x (ConsSig t1)        (ConsSig t2)           = ConsSig           <$> appZ <$> zipType γ x t1 t2
+zipElts γ x (IndexSig _ _ t1)   (IndexSig x2 b2 t2)    = IndexSig x2 b2    <$> appZ <$> zipType γ x t1 t2
 zipElts γ x (FieldSig _ _ _ t1) (FieldSig x2 o2 m2 t2) = FieldSig x2 o2 m2 <$> appZ <$> zipType γ x t1 t2
 zipElts γ x (MethSig _  t1)     (MethSig x2 t2)        = MethSig  x2       <$> appZ <$> zipType γ x t1 t2
 zipElts _ _ _                   _                      = Nothing
@@ -701,50 +714,50 @@ expandTypeWithSub g x t = substThis' g (x,t) <$> expandType Coercive g t
 substThis x t         = F.subst (F.mkSubst [(thisSym,F.expr x)]) t
 
 substOffsetThis = emapReft (\_ -> V.trans vs () ()) []
-  where 
+  where
     vs     = V.defaultVisitor { V.txExpr = tx }
     tx _ (F.EApp o [ F.EVar x, F.ESym (F.SL f) ])
-           | F.symbol o == offsetSym, F.symbol x == thisSym 
-           = F.eVar f 
+           | F.symbol o == offsetSym, F.symbol x == thisSym
+           = F.eVar f
     tx _ e = e
 
 
--- | Substitute occurences of 'this' in type @t'@, given that the receiver 
+-- | Substitute occurences of 'this' in type @t'@, given that the receiver
 --   object is bound to symbol @x@ and it has a type @t@ under @g@.
 -------------------------------------------------------------------------------
-substThis' :: (IsLocated a, F.Symbolic a) 
+substThis' :: (IsLocated a, F.Symbolic a)
            => CGEnv -> (a, RefType) -> RefType -> RefType
 -------------------------------------------------------------------------------
 substThis' g (x,t) = F.subst su
   where
     su            = F.mkSubst $ (this, F.expr $ F.symbol x) : fieldSu
-    this          = F.symbol $ builtinOpId BIThis 
+    this          = F.symbol $ builtinOpId BIThis
 
-    fieldSu       | Just (TCons _ fs _) <- expandType Coercive g t 
+    fieldSu       | Just (TCons _ fs _) <- expandType Coercive g t
                   = [ subPair f | ((f,InstanceMember), FieldSig _ _ m _) <- M.toList fs
                                 , isImmutable m ]
-                  | otherwise                              
+                  | otherwise
                   = []
-    qFld x f      = F.qualifySymbol (F.symbol x) f  
+    qFld x f      = F.qualifySymbol (F.symbol x) f
     subPair f     = (qFld this f, F.expr $ qFld x f)
 
 
- 
+
 -- | Substitute occurences of 'this.f' in type @t'@, with 'f'
 -------------------------------------------------------------------------------
 unqualifyThis :: CGEnv -> RefType -> RefType -> RefType
 -------------------------------------------------------------------------------
 unqualifyThis g t = F.subst $ F.mkSubst fieldSu
   where
-    fieldSu       | Just (TCons _ fs _) <- expandType Coercive g t 
+    fieldSu       | Just (TCons _ fs _) <- expandType Coercive g t
                   = [ subPair f | ((f,InstanceMember), FieldSig _ _ m _) <- M.toList fs
                                 , isImmutable m ]
-                  | otherwise                              
+                  | otherwise
                   = []
-    this          = F.symbol $ builtinOpId BIThis 
-    qFld x f      = F.qualifySymbol (F.symbol x) f  
+    this          = F.symbol $ builtinOpId BIThis
+    qFld x f      = F.qualifySymbol (F.symbol x) f
     subPair f     = (qFld this f, F.expr f)
- 
+
 
 -------------------------------------------------------------------------------
 mkQualSym :: (F.Symbolic x, F.Symbolic f) => x -> f -> F.Symbol
@@ -755,4 +768,3 @@ mkQualSym    x f = F.qualifySymbol (F.symbol x) (F.symbol f)
 mkOffset :: (F.Symbolic f, F.Expression x) => x -> f -> F.Expr
 -------------------------------------------------------------------------------
 mkOffset x f = F.EApp offsetLocSym [F.expr x, F.expr $ F.symbolText $ F.symbol f]
-

--- a/src/Language/Nano/Liquid/Types.hs
+++ b/src/Language/Nano/Liquid/Types.hs
@@ -284,31 +284,30 @@ rTypeSort (TModule _)              = F.FApp (rawStringFTycon $ F.symbol "module"
 rTypeSort (TEnum _)                = F.FApp (rawStringFTycon $ F.symbol "enum"  ) []
 rTypeSort t                        = error $ render $ text "BUG: rTypeSort does not support " <+> pp t
 
-rTypeSortApp TInt _                = F.FInt
+rTypeSortApp TInt _                = F.intSort
 rTypeSortApp TUn  _                = F.FApp (tconFTycon TUn) []
+rTypeSortApp TFPBool _             = F.boolSort
+rTypeSortApp TString _             = F.strSort
 rTypeSortApp c ts                  = F.FApp (tconFTycon c) (rTypeSort <$> ts)
 
+
 tconFTycon :: TCon -> F.FTycon
-tconFTycon TInt                    = F.intFTyCon
-tconFTycon TBV32                   = error "tconFTycon should be unreachable for BV32" -- BV.mkSort BV.S32 -- BV.bvTyCon
 tconFTycon TBool                   = rawStringFTycon "Boolean"
-tconFTycon TFPBool                 = F.boolFTyCon
 tconFTycon TVoid                   = rawStringFTycon "Void"
 tconFTycon TUn                     = rawStringFTycon "Union"
-tconFTycon TString                 = F.strFTyCon
 tconFTycon TTop                    = rawStringFTycon "Top"
 tconFTycon TNull                   = rawStringFTycon "Null"
 tconFTycon TUndef                  = rawStringFTycon "Undefined"
+tconFTycon c                       = error $ "impossible: tconFTycon " ++ show c
 
-
-rTypeSortForAll t    = genSort n θ $ rTypeSort tbody
+rTypeSortForAll t                  = genSort n θ $ rTypeSort tbody
   where
-    (αs, tbody)      = bkAll t
-    n                = length αs
-    θ                = HM.fromList $ zip (F.symbol <$> αs) (F.FVar <$> [0..])
+    (αs, tbody)                    = bkAll t
+    n                              = length αs
+    θ                              = HM.fromList $ zip (F.symbol <$> αs) (F.FVar <$> [0..])
 
-genSort n θ (F.FFunc _ t)  = F.FFunc n (F.sortSubst θ <$> t)
-genSort n θ t              = F.FFunc n [F.sortSubst θ t]
+genSort n θ (F.FFunc _ t)          = F.FFunc n (F.sortSubst θ <$> t)
+genSort n θ t                      = F.FFunc n [F.sortSubst θ t]
 
 ------------------------------------------------------------------------------------------
 stripRTypeBase :: RTypeQ q r -> Maybe r

--- a/src/Language/Nano/Liquid/Types.hs
+++ b/src/Language/Nano/Liquid/Types.hs
@@ -322,9 +322,7 @@ stripRTypeBase _              = Nothing
 ------------------------------------------------------------------------------------------
 noKVars :: F.Reft -> F.Reft
 ------------------------------------------------------------------------------------------
-noKVars r = F.traceFix ("noKVars r = " ++ F.showFix r) $ noKVars' r
-
-noKVars' (F.Reft (x, F.Refa p)) = F.Reft (x, F.Refa $ dropKs p)
+noKVars (F.Reft (x, F.Refa p)) = F.Reft (x, F.Refa $ dropKs p)
   where
     dropKs                     = F.pAnd . filter (not . isK) . F.conjuncts
     isK (F.PKVar {})           = True

--- a/src/Language/Nano/Liquid/Types.hs
+++ b/src/Language/Nano/Liquid/Types.hs
@@ -322,7 +322,9 @@ stripRTypeBase _              = Nothing
 ------------------------------------------------------------------------------------------
 noKVars :: F.Reft -> F.Reft
 ------------------------------------------------------------------------------------------
-noKVars (F.Reft (x, F.Refa p)) = F.Reft (x, F.Refa $ dropKs p)
+noKVars r = F.traceFix ("noKVars r = " ++ F.showFix r) $ noKVars' r
+
+noKVars' (F.Reft (x, F.Refa p)) = F.Reft (x, F.Refa $ dropKs p)
   where
     dropKs                     = F.pAnd . filter (not . isK) . F.conjuncts
     isK (F.PKVar {})           = True

--- a/src/Language/Nano/Types.hs
+++ b/src/Language/Nano/Types.hs
@@ -16,11 +16,11 @@ import           Data.Monoid
 import           Data.Function                      (on)
 import qualified Data.Map.Strict                 as M
 import           Data.Typeable                      (Typeable)
-import           Data.Generics                      (Data)   
+import           Data.Generics                      (Data)
 import           Data.List                          ((\\))
-import           Data.Traversable            hiding (sequence, mapM) 
-import           Data.Foldable                      (Foldable()) 
-import           Language.Nano.Syntax 
+import           Data.Traversable            hiding (sequence, mapM)
+import           Data.Foldable                      (Foldable())
+import           Language.Nano.Syntax
 import           Language.Nano.Syntax.PrettyPrint          (PP (..))
 
 import qualified Language.Fixpoint.Types         as F
@@ -38,11 +38,11 @@ import           Text.PrettyPrint.HughesPJ
 
 
 -- | Type Variables
-data TVar = TV { 
+data TVar = TV {
 
     tv_sym :: F.Symbol
 
-  , tv_loc :: SrcSpan 
+  , tv_loc :: SrcSpan
 
   } deriving (Show, Data, Typeable)
 
@@ -61,77 +61,77 @@ data TCon
   | TFPBool             -- ^ liquid 'bool'
     deriving (Ord, Show, Data, Typeable)
 
--- | (Raw) Refined Types 
+-- | (Raw) Refined Types
 data RTypeQ q r =
-  -- 
+  --
   -- ^ C T1,...,Tn
   --
     TApp TCon [RTypeQ  q r] r
-  -- 
+  --
   -- ^ A
   --
-  | TVar TVar r               
-  -- 
+  | TVar TVar r
+  --
   -- ^ ([Tthis], xi:T1, .., xn:Tn) => T
   --
   | TFun (Maybe (RTypeQ q r)) [BindQ q r] (RTypeQ q r) r
-  -- 
-  -- ^ {f1:T1,..,fn:Tn} 
+  --
+  -- ^ {f1:T1,..,fn:Tn}
   --
   | TCons (MutabilityQ q) (TypeMembersQ q r) r
-  -- 
+  --
   -- ^ forall A. T
   --
   | TAll TVar (RTypeQ q r)
-  -- 
+  --
   -- ^ /\ (T1..) => T1' ... /\ (Tn..) => Tn'
   --
-  | TAnd [RTypeQ q r]                                   
+  | TAnd [RTypeQ q r]
   --
   -- ^ Type Reference
   --
   | TRef (QN q) [RTypeQ  q r] r
-  -- 
+  --
   -- ^ typeof A.B.C (class)
-  -- 
+  --
   | TClass (QN q)
-  -- 
+  --
   -- ^ typeof L.M.N (module)
   --
   | TModule (QP q)
-  -- 
-  -- ^ enumeration L.M.N 
-  -- 
+  --
+  -- ^ enumeration L.M.N
+  --
   | TEnum (QN q)
-  -- 
+  --
   -- ^ Self type (with Mutability)
   --
   | TSelf (RTypeQ q r)
-  -- 
+  --
   -- ^ "Expression" parameters for type-aliases: never appear in real/expanded RType
   --
   | TExp F.Expr
 
     deriving (Show, Data, Typeable)
 
-deriving instance Functor (RTypeQ q) 
+deriving instance Functor (RTypeQ q)
 deriving instance Traversable (RTypeQ q)
 deriving instance Foldable (RTypeQ q)
 
 
--- 
+--
 -- The main typechecking RType uses absolute paths
 --
 type RType = RTypeQ AK
- 
+
 
 type TypeMembersQ q r = M.Map (F.Symbol, StaticKind) (TypeMemberQ q r)
 
 type TypeMembers r = M.Map (F.Symbol, StaticKind) (TypeMember r)
 
-data StaticKind = 
-    StaticMember 
-  | InstanceMember 
+data StaticKind =
+    StaticMember
+  | InstanceMember
   deriving (Eq, Ord, Show, Data, Typeable)
 
 
@@ -140,12 +140,12 @@ type Type    = RType ()
 
 
 -- | Type binder
-data BindQ  q r = B { 
+data BindQ  q r = B {
 
-  -- 
+  --
   -- ^ Binding's symbol
   --
-    b_sym  :: F.Symbol                              
+    b_sym  :: F.Symbol
   --
   -- ^ Field type
   --
@@ -153,52 +153,52 @@ data BindQ  q r = B {
 
   } deriving (Eq, Show, Data, Typeable)
 
-deriving instance Functor (BindQ q) 
+deriving instance Functor (BindQ q)
 deriving instance Traversable (BindQ q)
 deriving instance Foldable (BindQ q)
 
 type Bind = BindQ AK
 
 
-data FuncInputs t = FI { 
+data FuncInputs t = FI {
     fi_self :: Maybe t
-  , fi_args :: [t] 
-  } 
+  , fi_args :: [t]
+  }
   deriving (Functor, Traversable, Foldable)
 
 
 ---------------------------------------------------------------------------------
--- | Interface definitions 
+-- | Interface definitions
 ---------------------------------------------------------------------------------
 
 data IfaceKind = ClassKind | InterfaceKind
   deriving (Eq, Show, Data, Typeable)
 
 data IfaceDefQ q r = ID {
-  -- 
-  -- ^ The full name of the type 
-  -- 
-    t_name  :: QN q 
-  -- 
+  --
+  -- ^ The full name of the type
+  --
+    t_name  :: QN q
+  --
   -- ^ Kind
   --
   , t_class :: IfaceKind
-  -- 
+  --
   -- ^ Type variables
   --
-  , t_args  :: ![TVar]                             
-  -- 
+  , t_args  :: ![TVar]
+  --
   -- ^ Heritage
   --
   , t_base  :: !(HeritageQ q r)
-  -- 
-  -- ^ List of data type elts 
+  --
+  -- ^ List of data type elts
   --
   , t_elts  :: !(TypeMembersQ q r)
-  } 
+  }
   deriving (Eq, Show, Data, Typeable)
 
-deriving instance Functor (IfaceDefQ q) 
+deriving instance Functor (IfaceDefQ q)
 deriving instance Traversable (IfaceDefQ q)
 deriving instance Foldable (IfaceDefQ q)
 
@@ -221,44 +221,44 @@ data IndexKind          = StringIndex | NumericIndex
 
 
 data TypeMemberQ  q r
-  -- 
+  --
   -- ^ Call signature
   --
   = CallSig   { f_type :: RTypeQ q r }
-  -- 
+  --
   -- ^ Constructor signature
   --
   | ConsSig   { f_type :: RTypeQ q r }
-  -- 
+  --
   -- ^ Index signature
   --
   | IndexSig  { f_sym  :: F.Symbol
               , f_key  :: IndexKind
               , f_type :: RTypeQ q r }
-  -- 
+  --
   -- ^ Field signature
   --
-  | FieldSig  { f_sym  :: F.Symbol                      -- ^ Name  
+  | FieldSig  { f_sym  :: F.Symbol                      -- ^ Name
               , f_opt  :: (OptionalityQ q)              -- ^ Optional
               , f_mut  :: (MutabilityQ q)               -- ^ Mutability
               , f_type :: RTypeQ  q r }                 -- ^ Property type (could be function)
-  -- 
+  --
   -- ^ Method signature
   --
-  | MethSig   { f_sym  :: F.Symbol                      -- ^ Name  
+  | MethSig   { f_sym  :: F.Symbol                      -- ^ Name
               , f_type :: RTypeQ  q r }                 -- ^ Method type (also encodes mutability
                                                         --   through the 'this' binding
 
   deriving (Show, Data, Typeable)
 
-deriving instance Functor (TypeMemberQ q) 
+deriving instance Functor (TypeMemberQ q)
 deriving instance Traversable (TypeMemberQ q)
 deriving instance Foldable (TypeMemberQ q)
 
 type TypeMember = TypeMemberQ AK
 
-data Visibility 
-  = Local 
+data Visibility
+  = Local
   | Exported
   deriving (Show, Eq, Data, Typeable)
 
@@ -268,11 +268,11 @@ data Visibility
 ---------------------------------------------------------------------------------
 
 data EnumDef = EnumDef {
-    -- 
+    --
     -- ^ Name
     --
       e_name       :: F.Symbol
-    -- 
+    --
     -- ^ Contents: Symbols -> Expr (expected IntLit or HexLit)
     --
     , e_mapping    :: Env (Expression ())
@@ -281,24 +281,24 @@ data EnumDef = EnumDef {
 
 
 ------------------------------------------------------------------------------------------
--- | Module Body 
+-- | Module Body
 ------------------------------------------------------------------------------------------
 --
 --  As per TypeScript spec par. 10.2:
 --
 --  Each module body has a declaration space for local variables (including
---  functions, modules, class constructor functions, and enum objects), a 
+--  functions, modules, class constructor functions, and enum objects), a
 --  declaration space for local named types (classes, interfaces, and enums),
 --  and a declaration space for local namespaces (containers of named types).
---  Every declaration (whether local or exported) in a module contributes to 
+--  Every declaration (whether local or exported) in a module contributes to
 --  one or more of these declaration spaces.
 --
 --  PV: the last case has not been included
 --
 data ModuleDefQ q r = ModuleDef {
-  -- 
+  --
   -- ^ Contents of a module (local and exported)
-  --   
+  --
   --   * Interfaces are _not_ included here (because thery don't appear as
   --   bindings in the language)
   --
@@ -307,74 +307,74 @@ data ModuleDefQ q r = ModuleDef {
   -- ^ Types
   --
   , m_types       :: Env (IfaceDefQ q r)
-  -- 
+  --
   -- ^ Enumerations
   --
   , m_enums       :: Env EnumDef
-  -- 
+  --
   -- ^ Absolute path of definition
   --
   , m_path        :: AbsPath
   }
   deriving (Data, Typeable)
 
-deriving instance Functor (ModuleDefQ q) 
+deriving instance Functor (ModuleDefQ q)
 
 type ModuleDef = ModuleDefQ AK
 
 instance Monoid (ModuleDefQ q r) where
   mempty = ModuleDef mempty mempty mempty def
-  ModuleDef v t e p `mappend` ModuleDef v' t' e' _ = ModuleDef (v `mappend` v') 
+  ModuleDef v t e p `mappend` ModuleDef v' t' e' _ = ModuleDef (v `mappend` v')
                                                                (t `mappend` t')
                                                                (e `mappend` e')
-                                                               p 
+                                                               p
 
 
 ------------------------------------------------------------------------------------------
--- | Assignability 
+-- | Assignability
 ------------------------------------------------------------------------------------------
 
-data Assignability 
-  -- 
+data Assignability
+  --
   -- ^ Import,  cannot be modified
   -- ^ Contains: FunctionStmts, Measures, Classes, Modules.
   -- ^ Can appear in refinements
   --
-  = ReadOnly    
-  -- 
+  = ReadOnly
+  --
   -- ^ Like ReadOnly but for function declarations with no body
   -- ^ Can appear in refinements.
   --
   | ImportDecl
-  -- 
+  --
   -- ^ written in local-scope, can be SSA-ed
   -- ^ Can appear in refinements
   --
-  | WriteLocal  
-  -- 
+  | WriteLocal
+  --
   -- ^ Local but not in current scope.
   -- ^ CANNOT appear in refinements, cannot be read at SSA
   --
   | ForeignLocal
-  -- 
+  --
   -- ^ Written in non-local-scope, cannot do SSA
   -- ^ CANNOT appear in refinements
   --
-  | WriteGlobal 
-  -- 
+  | WriteGlobal
+  --
   -- ^ Used to denote return variable
   -- ^ CANNOT appear in refinements
-  -- 
+  --
   | ReturnVar
   deriving (Show, Eq, Data, Typeable)
 
 
 ---------------------------------------------------------------------------------
--- | Mutability 
+-- | Mutability
 ---------------------------------------------------------------------------------
 
 type MutabilityQ q = RTypeQ q ()
-type Mutability    = Type 
+type Mutability    = Type
 
 
 ---------------------------------------------------------------------------------
@@ -404,17 +404,17 @@ instance Monoid Initialization where
 ---------------------------------------------------------------------------------
 
 
-instance Eq TVar where 
+instance Eq TVar where
   a == b = tv_sym a == tv_sym b
 
-instance IsLocated TVar where 
+instance IsLocated TVar where
   srcPos = tv_loc
 
 instance IsLocated (TypeMember r) where
   srcPos _ = srcPos dummySpan
 
-instance Hashable TVar where 
-  hashWithSalt i α = hashWithSalt i $ tv_sym α 
+instance Hashable TVar where
+  hashWithSalt i α = hashWithSalt i $ tv_sym α
 
 instance Hashable StaticKind where
   hashWithSalt _ StaticMember   = 0
@@ -422,25 +422,25 @@ instance Hashable StaticKind where
 
 
 instance F.Symbolic TVar where
-  symbol = tv_sym 
+  symbol = tv_sym
 
-instance F.Symbolic a => F.Symbolic (Located a) where 
+instance F.Symbolic a => F.Symbolic (Located a) where
   symbol = F.symbol . val
 
 
 instance Eq TCon where
-  TInt     == TInt     = True   
-  TBV32    == TBV32    = True   
-  TBool    == TBool    = True           
+  TInt     == TInt     = True
+  TBV32    == TBV32    = True
+  TBool    == TBool    = True
   TString  == TString  = True
-  TVoid    == TVoid    = True         
+  TVoid    == TVoid    = True
   TTop     == TTop     = True
   TUn      == TUn      = True
   TNull    == TNull    = True
   TUndef   == TUndef   = True
   TFPBool  == TFPBool  = True
   _        == _        = False
- 
+
 
 -- Ignoring refinements in equality check
 instance Eq q => Eq (RTypeQ  q r) where
@@ -459,14 +459,14 @@ instance Eq q => Eq (RTypeQ  q r) where
   _               == _               = False
 
 
-instance Eq q => Eq (TypeMemberQ q r) where 
+instance Eq q => Eq (TypeMemberQ q r) where
   CallSig t1           == CallSig t2           = t1 == t2
   ConsSig t1           == ConsSig t2           = t1 == t2
   IndexSig _ b1 t1     == IndexSig _ b2 t2     = (b1,t1) == (b2,t2)
   FieldSig f1 o1 m1 t1 == FieldSig f2 o2 m2 t2 = (f1,o1,m1,t1) == (f2,o2,m2,t2)
   MethSig  f1 t1       == MethSig f2 t2        = (f1,t1) == (f2,t2)
   _                    == _                    = False
- 
+
 
 -- USE CAREFULLY !!!
 instance Eq q => Ord (RTypeQ q r) where
@@ -521,7 +521,7 @@ data BuiltinOp = BIUndefined
                  deriving (Eq, Ord, Show)
 
 instance PP BuiltinOp where
-  pp = text . show 
+  pp = text . show
 
 
 -----------------------------------------------------------------------------
@@ -541,14 +541,14 @@ class CallSite a where
 instance CallSite Int where
   siteIndex i = i
 
-newtype IContext = IC [Int] 
+newtype IContext = IC [Int]
                    deriving (Eq, Ord, Show, Data, Typeable)
 
 emptyContext         :: IContext
 emptyContext         = IC []
 
 pushContext          :: (CallSite a) => a -> IContext -> IContext
-pushContext s (IC c) = IC ((siteIndex s) : c) 
+pushContext s (IC c) = IC ((siteIndex s) : c)
 
 
 instance PP Int where
@@ -556,8 +556,8 @@ instance PP Int where
 
 ppArgs p sep l = p $ intersperse sep $ map pp l
 
-instance PP a => PP [a] where 
-  pp = ppArgs brackets comma 
+instance PP a => PP [a] where
+  pp = ppArgs brackets comma
 
 instance PP IContext where
   pp (IC x) = text "Context: " <+> pp x
@@ -573,13 +573,13 @@ instance PP Initialization where
 
 data Alias a s t = Alias {
     al_name   :: Id SrcSpan     -- ^ alias name
-  , al_tyvars :: ![a]           -- ^ type  parameters  
-  , al_syvars :: ![s]           -- ^ value parameters 
+  , al_tyvars :: ![a]           -- ^ type  parameters
+  , al_syvars :: ![s]           -- ^ value parameters
   , al_body   :: !t             -- ^ alias body
   } deriving (Eq, Ord, Show, Functor, Data, Typeable)
 
 type TAlias t    = Alias TVar F.Symbol t
-type PAlias      = Alias ()   F.Symbol F.Pred 
+type PAlias      = Alias ()   F.Symbol F.Pred
 type TAliasEnv t = Env (TAlias t)
 type PAliasEnv   = Env PAlias
 
@@ -587,12 +587,11 @@ instance IsLocated (Alias a s t) where
   srcPos = srcPos . al_name
 
 instance (PP a, PP s, PP t) => PP (Alias a s t) where
-  pp (Alias n _ _ body) = text "alias" <+> pp n <+> text "=" <+> pp body 
-   
+  pp (Alias n _ _ body) = text "alias" <+> pp n <+> text "=" <+> pp body
+
 ---------------------------------------------------------------------------------
 ---------------------------------------------------------------------------------
 
 -- Local Variables:
 -- flycheck-disabled-checkers: (haskell-liquid)
 -- End:
-

--- a/tests/neg/arrays/arr-15b.ts
+++ b/tests/neg/arrays/arr-15b.ts
@@ -1,6 +1,6 @@
 
 /*@ revInc :: forall M . (Array<Mutable,number>) 
-           => { IArray<number> | true } */
+           => { IArray<number> | 0 < 1 } */
 function revInc(a: number[]) {
 
   a.reverse();

--- a/tests/neg/arrays/filter-00.ts
+++ b/tests/neg/arrays/filter-00.ts
@@ -1,15 +1,15 @@
 
-/*@ array_filter :: forall T. (IArray<T>, (x:T) => boolean) => {IArray<T> | true} */
+/*@ array_filter :: forall T. (IArray<T>, (x:T) => boolean) => {IArray<T> | 0 < 1} */
 function array_filter(a, f) {
     return array_filter(a, f);
 }
 
-/*@ is_num :: (x:number) => {boolean | true} */
+/*@ is_num :: (x:number) => {boolean | 0 < 1} */
 function is_num(x:any) {
     return !isNaN(x);
 }
 
-/*@ foo :: (IArray<number + undefined>) => {IArray<number> | true} */ 
+/*@ foo :: (IArray<number + undefined>) => {IArray<number> | 0 < 1} */ 
 function foo(arr:any, f:any) {
   return array_filter(arr, is_num);
 }

--- a/tests/neg/arrays/filter-01.ts
+++ b/tests/neg/arrays/filter-01.ts
@@ -1,10 +1,10 @@
 
-/*@ is_num :: (x:number) => {boolean | true} */
+/*@ is_num :: (x:number) => {boolean | 0 < 1} */
 function is_num(x:any) {
     return !isNaN(x);
 }
 
-/*@ foo :: (IArray<number + undefined>) => {IArray<number> | true} */ 
+/*@ foo :: (IArray<number + undefined>) => {IArray<number> | 0 < 1} */ 
 function foo(arr:any) {
     return arr.filter(is_num);
 }

--- a/tests/neg/arrays/map-01.ts
+++ b/tests/neg/arrays/map-01.ts
@@ -1,5 +1,5 @@
 
-/*@ bar :: (IArray<number>, (number, number, number, number) => string) => { IArray<string> | true} */ 
+/*@ bar :: (IArray<number>, (number, number, number, number) => string) => { IArray<string> | 0 < 1 } */ 
 function bar(arr, f) {
   return arr.map(f);
 }

--- a/tests/neg/classes/class-10.ts
+++ b/tests/neg/classes/class-10.ts
@@ -1,4 +1,4 @@
-/*@ foo :: (x: Node<Mutable> + undefined) => { void | true } */
+/*@ foo :: (x: Node<Mutable> + undefined) => { void | 0 < 1} */
 function foo(x: Node) {
   if (x) {
     x.field = 2;

--- a/tests/neg/classes/init-01.ts
+++ b/tests/neg/classes/init-01.ts
@@ -5,7 +5,7 @@ class PosPoint {
     /*@ y: [#Mutable]{ number | v >= 0 } */
     y: number;
 
-    /*@ new (a: number, b: number) => { PosPoint<M> | true } */
+    /*@ new (a: number, b: number) => { PosPoint<M> | 0 < 1 } */
     constructor(a: number, b: number) {
         if (a > 0 && b > 0) { this.x = a; this.y = b; }
         else                { this.x = 0; this.y = -1; }

--- a/tests/neg/inclusion/forin-01.ts
+++ b/tests/neg/inclusion/forin-01.ts
@@ -2,7 +2,7 @@
 /*@ qualif Bot(v:a,s:string): hasProperty(v,s) */
 /*@ qualif Bot(v:a,s:string): enumProp(v,s) */
 
-/*@ foo :: (o: { [x:string]: string + number }) => { number | true } */ 
+/*@ foo :: (o: { [x:string]: string + number }) => { number | 0 < 1 } */ 
 function foo(o) {
   for (var x in o) {
     var r = o[x];

--- a/tests/neg/inclusion/forin-02.ts
+++ b/tests/neg/inclusion/forin-02.ts
@@ -2,7 +2,7 @@
 /*@ qualif Bot(v:a,s:string): hasProperty(v,s) */
 /*@ qualif Bot(v:a,s:string): enumProp(v,s) */
 
-/*@ foo :: (o: [Immutable]{ [x:string]: string }) => { MArray<string> | true } */ 
+/*@ foo :: (o: [Immutable]{ [x:string]: string }) => { MArray<string> | 0 < 1 } */ 
 function foo(o) {
 
   var ret = [];

--- a/tests/neg/loops/for-rec-01.ts
+++ b/tests/neg/loops/for-rec-01.ts
@@ -1,4 +1,4 @@
-/*@ forloop :: forall A. ({v:number | true}, number, (number, A) => A, A) => A */
+/*@ forloop :: forall A. ({v:number | 0 < 1}, number, (number, A) => A, A) => A */
 function forloop(lo, hi, body, acc){
   if (lo < hi) {
     var newAcc = body(acc, lo);

--- a/tests/neg/loops/while-05.ts
+++ b/tests/neg/loops/while-05.ts
@@ -1,4 +1,4 @@
-/*@ foo :: (n: number) => { boolean | true } */
+/*@ foo :: (n: number) => { boolean | 0 < 1} */
 function foo(n: number) {
   var b; 
   var i;

--- a/tests/neg/misc/abs-bad.ts
+++ b/tests/neg/misc/abs-bad.ts
@@ -3,7 +3,7 @@
 
 
 
-/*@ abs :: ({ x:number | true }) => number */ 
+/*@ abs :: ({ x:number | 0 < 1}) => number */ 
 function abs(x){
   var res = 0;
   if (x > 0) {

--- a/tests/neg/misc/abs-hof.ts
+++ b/tests/neg/misc/abs-hof.ts
@@ -16,7 +16,7 @@ function dubble(p) {
 }
 
 
-/*@ main :: (y:number) => {v:number | true} */
+/*@ main :: (y:number) => {v:number | 0 < 1} */
 function main(y) {
     var yy = abs(dubble, y);
     assert(yy >= 0);

--- a/tests/neg/misc/abs-join-01.ts
+++ b/tests/neg/misc/abs-join-01.ts
@@ -1,5 +1,5 @@
 
-/*@ abs :: ({ } + number) => { boolean | true } */ 
+/*@ abs :: ({ } + number) => { boolean | 0 < 1 } */ 
 
 function abs(x: any) {
 

--- a/tests/neg/misc/abs.ts
+++ b/tests/neg/misc/abs.ts
@@ -1,4 +1,4 @@
-/*@ abs :: ({ x:number | true }) => number */ 
+/*@ abs :: ({ x:number | 0 < 1}) => number */ 
 function abs(x){
   var y = x;
   if (x > 0) {

--- a/tests/neg/misc/animals-00.ts
+++ b/tests/neg/misc/animals-00.ts
@@ -33,7 +33,7 @@ class Tiger extends Animal {
   }
 }
 
-/*@ move :: (a: Animal<Immutable>) => { void | true } */
+/*@ move :: (a: Animal<Immutable>) => { void | 0 < 1} */
 function move(a: Animal) {
   var k = a.kind;
   if (a.kind === "horse") {

--- a/tests/neg/misc/animals-01.ts
+++ b/tests/neg/misc/animals-01.ts
@@ -25,7 +25,7 @@ class Snake extends Animal {
   }
 }
 
-/*@ move :: (a: Animal<Mutable>) => { void | true } */
+/*@ move :: (a: Animal<Mutable>) => { void | 0 < 1} */
 function move(a: Animal) {
 
   if (a.kind === "snake") {

--- a/tests/neg/misc/animals.ts
+++ b/tests/neg/misc/animals.ts
@@ -13,7 +13,7 @@ class Snake extends Animal {
   constructor() { super(); }
 }
 
-/*@ move :: (a: Animal) => { void | true } */
+/*@ move :: (a: Animal) => { void | 0 < 1} */
 function move(a: Animal) {
 
   if (a.kind === "snake") {

--- a/tests/neg/misc/array-tag-check.ts
+++ b/tests/neg/misc/array-tag-check.ts
@@ -1,9 +1,9 @@
 interface Foo<T> {}
-/*@ stringReduce :: (xf:Foo<Immutable, string>) => {void | true} */
+/*@ stringReduce :: (xf:Foo<Immutable, string>) => {void | 0 < 1} */
 declare function stringReduce(xf);
 
-/*@ reduce :: /\ (xf: Foo<Immutable, number>, coll:Array<Immutable, number>) => {void | true}
-              /\ (xf: Foo<Immutable, string>, coll:string)                   => {void | true} */
+/*@ reduce :: /\ (xf: Foo<Immutable, number>, coll:Array<Immutable, number>) => {void | 0 < 1}
+              /\ (xf: Foo<Immutable, string>, coll:string)                   => {void | 0 < 1} */
 function reduce(xf, coll) {
   if(typeof coll === "object") {
     stringReduce(xf);

--- a/tests/neg/misc/negate-07.ts
+++ b/tests/neg/misc/negate-07.ts
@@ -12,7 +12,7 @@ function nein(x){
     return !x;
 }
 
-/*@ negate :: /\ (x:number)  => {v:number | true} 
+/*@ negate :: /\ (x:number)  => {v:number | 0 < 1} 
               /\ (x:boolean) => boolean
 
 */

--- a/tests/neg/misc/poly-01.ts
+++ b/tests/neg/misc/poly-01.ts
@@ -10,7 +10,7 @@ function bar(x:any, f:any){
     return f(x);
 }
 
-/*@ main :: (number) => {string | true} */
+/*@ main :: (number) => {string | 0 < 1} */
 function main(x){
     return bar(x, idd); // this is actually (idd @ number)
 }

--- a/tests/neg/misc/unite-00.ts
+++ b/tests/neg/misc/unite-00.ts
@@ -1,4 +1,4 @@
-/*@ foo :: forall A B. (A, B) => {v:A | true} */
+/*@ foo :: forall A B. (A, B) => {v:A | 0 < 1} */
 function foo(x, y) {
   if (x === y) {
     return x;

--- a/tests/neg/misc/vararg-04.ts
+++ b/tests/neg/misc/vararg-04.ts
@@ -1,6 +1,6 @@
 
-/*@ foo :: /\ (x: number, y: (number) => number) => {number + undefined | true}
-           /\ (x: number) => {number + undefined | true} 
+/*@ foo :: /\ (x: number, y: (number) => number) => {number + undefined | 0 < 1 }
+           /\ (x: number) => {number + undefined | 0 < 1 } 
  */ 
 function foo(x: any, y?: any): any {
   var bobZooo = arguments.length;

--- a/tests/neg/objects/update-00.ts
+++ b/tests/neg/objects/update-00.ts
@@ -1,5 +1,5 @@
 
-/*@ foo :: ({ x: number }) => { void | true } */ 
+/*@ foo :: ({ x: number }) => { void | 0 < 1} */ 
 function foo(o) {
   o.y = "aaa";
 }

--- a/tests/neg/objects/update-02.ts
+++ b/tests/neg/objects/update-02.ts
@@ -1,5 +1,5 @@
 
-/*@ foo :: ({x: number}) => { void | true } */ 
+/*@ foo :: ({x: number}) => { void | 0 < 1} */ 
 function foo(o) {
   o.y = 10;
 }

--- a/tests/neg/operators/add-03.ts
+++ b/tests/neg/operators/add-03.ts
@@ -12,13 +12,13 @@ function num_num(a, b){
   return d; 
 }
 
-/*@ str_str :: (string) => {string | true } */
+/*@ str_str :: (string) => {string | 0 < 1} */
 function str_str(a){
   var b = "dog";
   return  myPlusOk(a, b); 
 }
 
-/*@ num_str :: (number) => {number | true } */
+/*@ num_str :: (number) => {number | 0 < 1} */
 function num_str(a){
   var b = "dog";
   return myPlusOk(a, b); 

--- a/tests/neg/operators/add-08.ts
+++ b/tests/neg/operators/add-08.ts
@@ -25,7 +25,7 @@ function num_one(a){
   return d; 
 }
 
-/*@ num_str :: (a:number) => {number | true} */
+/*@ num_str :: (a:number) => {number | 0 < 1} */
 function num_str(a){
   var d = myPlusOk(0, "cat");
   return d; 

--- a/tests/neg/operators/inc-00.ts
+++ b/tests/neg/operators/inc-00.ts
@@ -1,5 +1,5 @@
 
-/*@ inc :: ({number|true}) => void */
+/*@ inc :: ({number | 0 < 1 }) => void */
 function inc(x){
   var y = x + 1;
   assert(y > 0);

--- a/tests/neg/operators/stmt-00.ts
+++ b/tests/neg/operators/stmt-00.ts
@@ -1,5 +1,5 @@
 
-/*@ foo :: (number, boolean) => {number|true} */
+/*@ foo :: (number, boolean) => {number| 0 < 1} */
 function foo(x, y){
   x = x + 1;
   y = y + 1;

--- a/tests/neg/simple/cast-00.ts
+++ b/tests/neg/simple/cast-00.ts
@@ -8,7 +8,7 @@ class HTMLDivElt extends HTMLElt {
   constructor() { super(); }
 }
 
-/*@ foo :: (elt: { HTMLElt<Immutable> | true } ) => HTMLDivElt<Immutable> */
+/*@ foo :: (elt: { HTMLElt<Immutable> | 0 < 1} ) => HTMLDivElt<Immutable> */
 function foo(elt: HTMLElt): HTMLDivElt {
   if (elt instanceof HTMLCanvasElt) {
     var div = <HTMLDivElt>elt;

--- a/tests/neg/simple/loop-ssa.ts
+++ b/tests/neg/simple/loop-ssa.ts
@@ -1,13 +1,13 @@
 //adapted from splay-typed-octane.ts
 class ListNode {
-    /*@ new () => {ListNode<M> | true} */
+    /*@ new () => {ListNode<M> | 0 < 1 } */
     constructor() { }
     /*@ right : ListNode<Immutable> + null */
     public right = null;
 }
 
 
-/*@ traverse_ :: (ListNode<Immutable>) => {void | true} */
+/*@ traverse_ :: (ListNode<Immutable>) => {void | 0 < 1} */
 function traverse_(x) {
 
     /*@ local current :: ListNode<Immutable> + null */

--- a/tests/neg/simple/overload-00.ts
+++ b/tests/neg/simple/overload-00.ts
@@ -1,5 +1,5 @@
 
-/*@ foo :: (x: number + string) => { boolean | true } */
+/*@ foo :: (x: number + string) => { boolean | 0 < 1} */
 function foo(x: any): boolean  {
 
   return 1 < x;

--- a/tests/neg/simple/unif-04.ts
+++ b/tests/neg/simple/unif-04.ts
@@ -1,7 +1,7 @@
 //adapted from transducers
 class Foo<T> { constructor(){} }
-/*@ reduce :: /\            (Foo<Immutable, boolean>, string) => {void | true} 
-              /\ forall T . (Foo<Immutable, T>,       number) => {void | true} */
+/*@ reduce :: /\            (Foo<Immutable, boolean>, string) => {void | 0 < 1 } 
+              /\ forall T . (Foo<Immutable, T>,       number) => {void | 0 < 1 } */
 function reduce(xf, coll) {
     if (typeof coll === "number") {
         /*@ xxf :: Foo<Immutable, boolean> */

--- a/tests/neg/unions/choice-00.ts
+++ b/tests/neg/unions/choice-00.ts
@@ -1,14 +1,14 @@
-/*@ fails :: (number) => {number + undefined | true} */
+/*@ fails :: (number) => {number + undefined | 0 < 1 } */
 function fails (x:number):any { 
     return x ? true : undefined;
 }
 
-/*@ ok1 :: (number) => {number + undefined | true} */
+/*@ ok1 :: (number) => {number + undefined | 0 < 1 } */
 function ok1(x:number):any { 
     if (x) {return 10;} else {return undefined;}
 }
 
-/*@ ok2 :: (number) => {number + undefined | true} */
+/*@ ok2 :: (number) => {number + undefined | 0 < 1 } */
 function ok2(x:number):any { 
     /*@ z :: number + undefined */
     var z;

--- a/tests/neg/unions/noundef.ts
+++ b/tests/neg/unions/noundef.ts
@@ -12,7 +12,7 @@ function bob(x:number):any {
     return undefined;
 }
 
-/*@ bar :: ({number | true}) => number */
+/*@ bar :: ({number | 0 < 1 }) => number */
 function bar(x:number) : any {
     var z = bob(x);
     return z;

--- a/tests/neg/unions/undef-01.ts
+++ b/tests/neg/unions/undef-01.ts
@@ -9,12 +9,12 @@ function foo(x:number) {
     return res;
 }
 
-/*@ inc :: (x:number) => {number | true} */
+/*@ inc :: (x:number) => {number | 0 < 1} */
 function inc(x:number):number {
     return x + 1;
 }
 
-/*@ bar :: (y:number) => {number | true} */
+/*@ bar :: (y:number) => {number | 0 < 1 } */
 function bar(y:number):number {
     var z = foo(y);
     if (typeof z === "undefined"){

--- a/tests/neg/unions/union-05.ts
+++ b/tests/neg/unions/union-05.ts
@@ -1,6 +1,6 @@
 function noop(u) {}
 
-/*@ foo :: (u:boolean + null) => {number | true} */
+/*@ foo :: (u:boolean + null) => {number | 0 < 1} */
 function foo(u) {
   noop(u); 
   return "not a number"; // UNSAFE

--- a/tests/pos/classes/self.ts
+++ b/tests/pos/classes/self.ts
@@ -1,11 +1,11 @@
 class IdGen {
-  /*@ gen : (this: Self<Mutable>) : {number | true} */
+  /*@ gen : (this: Self<Mutable>) : {number | 0 < 1} */
   gen() { return 0 }
   constructor() { }
 }
 class UniqueIdGen extends IdGen {
   private next = -1;
-  /*@ gen : (this: Self<Mutable>) : {number | true} */
+  /*@ gen : (this: Self<Mutable>) : {number | 0 < 1} */
   gen() {
     this.next++;
     return this.next;

--- a/tests/todo/inc-00.ts
+++ b/tests/todo/inc-00.ts
@@ -1,0 +1,9 @@
+
+// We should get this to FAIL
+// inc :: ({number | 0 < 1 }) => void /
+
+export function inc(x:number): void {
+  var y = x + 1;
+  assert(y > 0);
+}
+


### PR DESCRIPTION
Many changes to bring `rsc` up-to-date with the latest `liquid-fixpoint`. 

Note that `true` is still considered a trivial refinement (but `0 < 1` is not) so we 
have to lamely denote `public` or `exported` functions with `0 < 1` -- which clearly 
needs to be fixed.
