### PR TITLE
Make (Haskell) Native Solver the default

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -4,6 +4,47 @@ Tests / Benchmarks
 See https://github.com/UCSD-PL/rs-benchmarks
 
 
+forin-01.ts:            FAIL (0.98s)
+  Wrong exit code
+  expected: ExitSuccess
+   but got: ExitFailure 1
+forin-000.ts:           FAIL (1.42s)
+  Wrong exit code
+  expected: ExitSuccess
+   but got: ExitFailure 1
+forin-00.ts:            FAIL (0.82s)
+  Wrong exit code
+  expected: ExitSuccess
+   but got: ExitFailure 1
+   minindex-modern.ts:     FAIL (0.90s)
+      Wrong exit code
+      expected: ExitSuccess
+       but got: ExitFailure 1
+    minindex-modern-lib.ts: FAIL (0.88s)
+      Wrong exit code
+      expected: ExitSuccess
+       but got: ExitFailure 1
+       arithmetic-option.ts:   FAIL (0.63s)
+       non-linear.ts:          FAIL (0.65s)
+       unif-00.ts:             FAIL (0.76s)
+       variadic-01.ts:         FAIL (0.73s)
+       minindex-02.ts:         FAIL (0.93s)
+              Wrong exit code
+              expected: ExitSuccess
+               but got: ExitFailure 1
+            minindex-01.ts:         FAIL (0.81s)
+              Wrong exit code
+              expected: ExitSuccess
+               but got: ExitFailure 1
+            minindex-00.ts:         FAIL (0.75s)
+              Wrong exit code
+              expected: ExitSuccess
+               but got: ExitFailure 1
+               poly-03.ts:             FAIL (0.98s)
+               arr-09.ts:              FAIL (0.73s)
+               string-idx.ts:          FAIL (0.90s)
+
+
 
 
 

--- a/include/prelude.ts
+++ b/include/prelude.ts
@@ -886,7 +886,7 @@ declare function builtin_OpIn(s: string, obj: Object): boolean;
  *
  ************************************************************************/
 
-/*@ qualif Bot(v:a): 0 = 1 */
+/*@ qualif Bot[A](v:A): 0 = 1 */
 /*@ qualif Bot(v:obj): 0 = 1 */
 /*@ qualif Bot(v:boolean): 0 = 1 */
 /*@ qualif Bot(v:int): 0 = 1 */
@@ -902,9 +902,12 @@ declare function builtin_OpIn(s: string, obj: Object): boolean;
 /*@ qualif Cmp(v:int,x:int): v >  x */
 /*@ qualif Cmp(v:int,x:int): v >= x */
 
-/*  qualif Cmp(v:a,x:a): v =  x */
-/*@ qualif Cmp(v:a,x:a): v ~~ x */
-/*@ qualif Cmp(v:a,x:a): v != x */
+/* qualif Cmp(v:a,x:a): v =  x */
+
+/*@ qualif CmpUEq[A](v:A, x:A): v ~~ x */
+
+/*@ qualif Cmp[A](v:A, x:A): v != x */
+
 /*  qualif True(v:boolean): (v) */
 /*  qualif False(v:boolean): (not v) */
 /*@ qualif True1(v:boolean): (Prop v) */
@@ -917,7 +920,7 @@ declare function builtin_OpIn(s: string, obj: Object): boolean;
 /*  qualif Add(v:int,x:int,y:int): v = x + y */
 /*  qualif Sub(v:int,x:int,y:int): v = x - y */
 
-/*@  qualif Len(v:b,w:a)  : v < (len w) */
+/*@  qualif Len(v:A, w:B)  : v < (len w) */
 
 
 

--- a/include/prelude.ts
+++ b/include/prelude.ts
@@ -886,7 +886,7 @@ declare function builtin_OpIn(s: string, obj: Object): boolean;
  *
  ************************************************************************/
 
-/*@ qualif Bot[A](v:A): 0 = 1 */
+/*@ qualif Bot<A>(v:A): 0 = 1 */
 /*@ qualif Bot(v:obj): 0 = 1 */
 /*@ qualif Bot(v:boolean): 0 = 1 */
 /*@ qualif Bot(v:int): 0 = 1 */
@@ -904,9 +904,9 @@ declare function builtin_OpIn(s: string, obj: Object): boolean;
 
 /* qualif Cmp(v:a,x:a): v =  x */
 
-/*@ qualif CmpUEq[A](v:A, x:A): v ~~ x */
+/*@ qualif CmpUEq<A>(v:A, x:A): v ~~ x */
 
-/*@ qualif Cmp[A](v:A, x:A): v != x */
+/*@ qualif Cmp<A>(v:A, x:A): v != x */
 
 /*  qualif True(v:boolean): (v) */
 /*  qualif False(v:boolean): (not v) */
@@ -920,7 +920,7 @@ declare function builtin_OpIn(s: string, obj: Object): boolean;
 /*  qualif Add(v:int,x:int,y:int): v = x + y */
 /*  qualif Sub(v:int,x:int,y:int): v = x - y */
 
-/*@  qualif Len(v:A, w:B)  : v < (len w) */
+/*@  qualif Len<A,B>(v:A, w:B)  : v < (len w) */
 
 
 

--- a/src/Language/Nano/Annots.hs
+++ b/src/Language/Nano/Annots.hs
@@ -22,7 +22,7 @@ module Language.Nano.Annots (
   , factRTypes
 
   -- Options
-  , RscOption (..)
+  -- , RscOption (..)
 
 ) where
 import           Control.Monad                  (void)
@@ -264,5 +264,6 @@ factRTypes = go
 -- | RSC Options
 -----------------------------------------------------------------------------
 
-data RscOption = RealOption
-    deriving (Eq, Show, Data, Typeable)
+--  data RscOption = OptReal
+--               | OptExtSolver
+--    deriving (Eq, Show, Data, Typeable)

--- a/src/Language/Nano/CmdLine.hs
+++ b/src/Language/Nano/CmdLine.hs
@@ -1,9 +1,16 @@
 {-# LANGUAGE TupleSections      #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 
-module Language.Nano.CmdLine (Config(..), config) where
+module Language.Nano.CmdLine (Config(..), config, withPragmas) where
 
 import System.Console.CmdArgs
+import System.Console.CmdArgs.Explicit (modeValue)
+-- import System.Console.CmdArgs.Implicit     hiding (Loud)
+-- import System.Console.CmdArgs.Text
+-- import Language.Fixpoint.Types
+import Language.Nano.Locations
+import Control.Monad (foldM)
+import System.Environment (withArgs)
 
 ---------------------------------------------------------------------
 -- | Command Line Configuration Options
@@ -19,6 +26,8 @@ data Config
            , extraInvs   :: Bool           -- ^ add extra invariants to object types
            , renderAnns  :: Bool           -- ^ render annotations
            , prelude     :: Maybe FilePath -- ^ use this prelude file
+           , real        :: Bool           -- ^ use real-valued SMT arithmetic
+           , extSolver   :: Bool           -- ^ use external (Ocaml) fixpoint solver
            }
   deriving (Data, Typeable, Show, Eq)
 
@@ -54,19 +63,39 @@ liquid = Liquid {
 
  , prelude      = def  &= help "Use given prelude.ts file (debug)"
 
+ , real         = def  &= help "Use real-valued SMT logic (slow!)"
+
+ , extSolver    = def  &= help "Use external (Ocaml) fixpoint solver"
+
  } &= help    "RefScript Refinement Type Checker"
 
-
-
 config :: Config
-config = modes [
-                 liquid &= auto
+config = modes [ liquid &= auto
                , tc
                ]
             &= help    "rsc is an optional refinement type checker for TypeScript"
             &= program "rsc"
             &= summary "rsc © Copyright 2013-15 Regents of the University of California."
             &= verbosity
+
+
+---------------------------------------------------------------------------------------
+withPragmas :: Config -> [Located String] -> IO Config
+---------------------------------------------------------------------------------------
+withPragmas = foldM withPragma
+
+withPragma :: Config -> Located String -> IO Config
+withPragma c s = withArgs [val s] $ cmdArgsRun
+                    cfg0 { modeValue = (modeValue cfg0) { cmdArgsValue = c } }
+  where
+    cfg0       = cmdArgsMode liquid
+
+---------------------------------------------------------------------------------------
+parsePragma :: Located String -> IO Config
+---------------------------------------------------------------------------------------
+parsePragma = withPragma config
+
+
 
 -- getOpts :: IO Config
 -- getOpts = do md <- cmdArgs config

--- a/src/Language/Nano/CmdLine.hs
+++ b/src/Language/Nano/CmdLine.hs
@@ -27,7 +27,7 @@ data Config
            , renderAnns  :: Bool           -- ^ render annotations
            , prelude     :: Maybe FilePath -- ^ use this prelude file
            , real        :: Bool           -- ^ use real-valued SMT arithmetic
-           , native      :: Bool           -- ^ use native (Haskell) fixpoint solver
+           , extSolver   :: Bool           -- ^ use external (Ocaml) fixpoint solver (deprecated)
            }
   deriving (Data, Typeable, Show, Eq)
 
@@ -65,7 +65,7 @@ liquid = Liquid {
 
  , real         = def  &= help "Use real-valued SMT logic (slow!)"
 
- , native       = def  &= help "Use native (Haskell) fixpoint solver"
+ , extSolver    = def  &= help "Use external (Ocaml) fixpoint solver (deprecated)"
 
  } &= help    "RefScript Refinement Type Checker"
 

--- a/src/Language/Nano/CmdLine.hs
+++ b/src/Language/Nano/CmdLine.hs
@@ -27,7 +27,7 @@ data Config
            , renderAnns  :: Bool           -- ^ render annotations
            , prelude     :: Maybe FilePath -- ^ use this prelude file
            , real        :: Bool           -- ^ use real-valued SMT arithmetic
-           , extSolver   :: Bool           -- ^ use external (Ocaml) fixpoint solver
+           , native      :: Bool           -- ^ use native (Haskell) fixpoint solver
            }
   deriving (Data, Typeable, Show, Eq)
 
@@ -65,7 +65,7 @@ liquid = Liquid {
 
  , real         = def  &= help "Use real-valued SMT logic (slow!)"
 
- , extSolver    = def  &= help "Use external (Ocaml) fixpoint solver"
+ , native       = def  &= help "Use native (Haskell) fixpoint solver"
 
  } &= help    "RefScript Refinement Type Checker"
 

--- a/src/Language/Nano/Liquid/Liquid.hs
+++ b/src/Language/Nano/Liquid/Liquid.hs
@@ -144,10 +144,10 @@ solveConstraints cfg p f cgi
        let sol  = applySolution s
        return (A.SomeAnn anns sol, r')
   where
-    fpConf      = def { C.real        = real cfg -- error "FIXME"
+    fpConf      = def { C.real        = real cfg
                       , C.ueqAllSorts = C.UAS True
                       , C.srcFile     = f
-                      , C.extSolver   = extSolver cfg -- error "FIXME"
+                      , C.extSolver   = not (native cfg)
                       }
 
 -- withUEqAllSorts c b = c { ueqAllSorts = UAS b }

--- a/src/Language/Nano/Liquid/Liquid.hs
+++ b/src/Language/Nano/Liquid/Liquid.hs
@@ -147,7 +147,7 @@ solveConstraints cfg p f cgi
     fpConf      = def { C.real        = real cfg
                       , C.ueqAllSorts = C.UAS True
                       , C.srcFile     = f
-                      , C.extSolver   = not (native cfg)
+                      , C.extSolver   = extSolver cfg
                       }
 
 -- withUEqAllSorts c b = c { ueqAllSorts = UAS b }

--- a/src/Language/Nano/Locations.hs
+++ b/src/Language/Nano/Locations.hs
@@ -19,11 +19,11 @@
 module Language.Nano.Locations (
 
   -- * Located Values
-    Located (..) 
+    Located (..)
   , IsLocated (..)
   , SrcSpan (..)
   , sourcePos
- 
+
   -- * Manipulating SrcSpan
   -- , SrcSpan (..)
   , dummySpan
@@ -32,7 +32,7 @@ module Language.Nano.Locations (
   , srcSpanEndLine
   , srcSpanStartCol
   , srcSpanEndCol
-  
+
   , sourceSpanSrcSpan
 
 
@@ -40,8 +40,8 @@ module Language.Nano.Locations (
 ) where
 
 import           Data.Typeable                      (Typeable)
-import           Data.Generics                      (Data)   
-import           Language.Nano.Syntax 
+import           Data.Generics                      (Data)
+import           Language.Nano.Syntax
 import           Language.Nano.Syntax.Annotations
 import           Language.Nano.Syntax.PrettyPrint   (PP (..))
 -- import           Language.ECMAScript3.Parser.Type   (SrcSpan (..))
@@ -54,7 +54,7 @@ import           Language.Fixpoint.PrettyPrint
 
 
 ---------------------------------------------------------------------
--- | Tracking Source Code Locations --------------------------------- 
+-- | Tracking Source Code Locations ---------------------------------
 ---------------------------------------------------------------------
 
 data Located a
@@ -62,8 +62,11 @@ data Located a
         , val :: a
         }
     deriving (Data, Typeable)
- 
-instance Functor Located where 
+
+instance Show a => Show (Located a) where
+  show = show . val
+  
+instance Functor Located where
   fmap f (Loc l x) = Loc l (f x)
 
 --------------------------------------------------------------------------------
@@ -71,43 +74,43 @@ instance Functor Located where
 --------------------------------------------------------------------------------
 
 sourcePos :: IsLocated a => a -> SourcePos
-sourcePos = sp_start . srcPos 
+sourcePos = sp_start . srcPos
 
-class IsLocated a where 
+class IsLocated a where
   srcPos :: a -> SrcSpan
 
 instance IsLocated Error where
-  srcPos = srcPos . errLoc 
+  srcPos = srcPos . errLoc
 
-instance IsLocated SrcSpan where 
-  srcPos x = x 
+instance IsLocated SrcSpan where
+  srcPos x = x
 
-instance IsLocated (Located a) where 
+instance IsLocated (Located a) where
   srcPos = loc
 
 instance IsLocated SourcePos where
-  srcPos x = SS x x 
+  srcPos x = SS x x
 
 instance IsLocated (F.Located a) where
   srcPos = srcPos . F.loc
 
-instance (HasAnnotation thing, IsLocated a) => IsLocated (thing a) where 
-  srcPos  = srcPos . getAnnotation  
+instance (HasAnnotation thing, IsLocated a) => IsLocated (thing a) where
+  srcPos  = srcPos . getAnnotation
 
-instance IsLocated F.Symbol where 
+instance IsLocated F.Symbol where
   srcPos _ = srcPos dummySpan
 
-instance IsLocated (SrcSpan, r) where 
+instance IsLocated (SrcSpan, r) where
   srcPos = srcPos . fst
 
-instance Eq a => Eq (Located a) where 
+instance Eq a => Eq (Located a) where
   x == y = val x == val y
 
-instance Ord a => Ord (Located a) where 
+instance Ord a => Ord (Located a) where
   x `compare` y = val x `compare` val y
 
 instance F.Fixpoint SrcSpan where
-  toFix = pp 
+  toFix = pp
 
 sourceSpanSrcSpan sp = SS (sp_start sp') (sp_stop sp') where sp' = srcPos sp
 
@@ -119,9 +122,8 @@ sourceSpanSrcSpan sp = SS (sp_start sp') (sp_stop sp') where sp' = srcPos sp
 instance PP SrcSpan where
   pp    = pprint
 
-srcSpanStartLine = snd3 . sourcePosElts . sp_start . sourceSpanSrcSpan   
+srcSpanStartLine = snd3 . sourcePosElts . sp_start . sourceSpanSrcSpan
 srcSpanEndLine   = snd3 . sourcePosElts . sp_stop  . sourceSpanSrcSpan
-srcSpanStartCol  = thd3 . sourcePosElts . sp_start . sourceSpanSrcSpan 
-srcSpanEndCol    = thd3 . sourcePosElts . sp_stop  . sourceSpanSrcSpan 
+srcSpanStartCol  = thd3 . sourcePosElts . sp_start . sourceSpanSrcSpan
+srcSpanEndCol    = thd3 . sourcePosElts . sp_stop  . sourceSpanSrcSpan
 srcSpanFile      = fst3 . sourcePosElts . sp_start . sourceSpanSrcSpan
-

--- a/src/Language/Nano/Program.hs
+++ b/src/Language/Nano/Program.hs
@@ -120,7 +120,7 @@ data Nano a r = Nano {
   --
   -- ^ Options
   --
-  , pOptions  :: [RscOption]
+  , pOptions  :: [Located String]
 
   } deriving (Functor) -- , Data, Typeable)
 

--- a/src/Language/Nano/Typecheck/Parse.hs
+++ b/src/Language/Nano/Typecheck/Parse.hs
@@ -583,14 +583,15 @@ parseAnnot = go
     go (RawExported (ss, _)) = return  $ Exported ss
     go (RawReadOnly (ss, _)) = return  $ RdOnly ss
 
-
 qualifierP = do
-  pos    <- getPosition
-  n      <- upperIdP
-  params <- parens $ sepBy1 qualParamP comma
-  _      <- colon
-  body   <- predP
-  return  $ mkQual n params body pos
+  pos     <- getPosition
+  n       <- upperIdP
+  as      <- try tParP <|> return []
+  xts     <- parens $ sepBy1 qualParamP comma
+  _       <- colon
+  body    <- predP
+  let xts' = [(x, convertTvar as t) | (x, t) <- xts]
+  return  $ mkQual n xts' body pos
 
 qualParamP = pairP symbolP colon btSortP
 btSortP    = rTypeSort <$> bareTypeP

--- a/src/Language/Nano/Typecheck/Parse.hs
+++ b/src/Language/Nano/Typecheck/Parse.hs
@@ -590,11 +590,13 @@ qualifierP = do
   xts     <- parens $ sepBy1 qualParamP comma
   _       <- colon
   body    <- predP
-  let xts' = [(x, convertTvar as t) | (x, t) <- xts]
+  let xts' = [(x, qpSort as t) | (x, t) <- xts]
   return  $ mkQual n xts' body pos
 
-qualParamP = pairP symbolP colon btSortP
-btSortP    = rTypeSort <$> bareTypeP
+qpSort as = rTypeSort . convertTvar as
+
+qualParamP = pairP symbolP colon bareTypeP
+-- btSortP    = rTypeSort <$> bareTypeP
 
 patch2 ss (x,t)   = (fmap (const ss) x , t)
 patch3 ss (x,a,t) = (fmap (const ss) x , a, t)

--- a/src/Language/Nano/Typecheck/Parse.hs
+++ b/src/Language/Nano/Typecheck/Parse.hs
@@ -47,7 +47,7 @@ import           Control.Monad
 import           Control.Monad.Trans                     (MonadIO,liftIO)
 import           Control.Applicative                     ((<$>), (<*>) , (<*) , (*>))
 
-import           Language.Fixpoint.Types          hiding (quals, Loc, Expression)
+import           Language.Fixpoint.Types          hiding (quals, Loc, Expression, Located)
 import           Language.Fixpoint.Parse
 import           Language.Fixpoint.Errors
 import           Language.Fixpoint.Misc                  (fst3)
@@ -151,7 +151,7 @@ aliasVarT (l, x)
 --
 -- PV: Insert your option parser here
 --
-optionP   = string "REALS" >> return RealOption
+-- optionP   = string "REALS" >> return RealOption
 
 iFaceP   :: Parser (Id SrcSpan, IfaceDefQ RK Reft)
 iFaceP
@@ -550,7 +550,7 @@ data PSpec l r
   | TAlias  (Id l, TAlias (RTypeQ RK r))
   | PAlias  (Id l, PAlias)
   | Qual    Qualifier
-  | Option  RscOption
+  | Option  (Located String)
   | Invt    l (RTypeQ RK r)
   | CastSp  l (RTypeQ RK r)
   | Exported l
@@ -577,7 +577,7 @@ parseAnnot = go
     go (RawTAlias   (ss, _)) = TAlias  <$> patch2 ss <$> tAliasP
     go (RawPAlias   (ss, _)) = PAlias  <$> patch2 ss <$> pAliasP
     go (RawQual     (_ , _)) = Qual    <$>               qualifierP btSortP
-    go (RawOption   (_ , _)) = Option  <$>               optionP
+    go (RawOption   (ss, o)) = return   $ Option         (Loc ss o)   -- <$> optionP
     go (RawInvt     (ss, _)) = Invt               ss <$> bareTypeP
     go (RawCast     (ss, _)) = CastSp             ss <$> bareTypeP
     go (RawExported (ss, _)) = return  $ Exported ss

--- a/src/Language/Nano/Typecheck/Parse.hs
+++ b/src/Language/Nano/Typecheck/Parse.hs
@@ -586,7 +586,7 @@ parseAnnot = go
 qualifierP = do
   pos     <- getPosition
   n       <- upperIdP
-  as      <- try tParP <|> return []
+  as      <- option [] tParP -- try tParP <|> return []
   xts     <- parens $ sepBy1 qualParamP comma
   _       <- colon
   body    <- predP

--- a/stack.yaml
+++ b/stack.yaml
@@ -16,4 +16,5 @@ flags:
 extra-deps:
 - intern-0.9.1.4
 - located-base-0.1.0.0
+- ascii-progress-0.2.1.2
 

--- a/tests/neg/inclusion/forin-00.ts
+++ b/tests/neg/inclusion/forin-00.ts
@@ -1,15 +1,15 @@
 
-/*@ qualif HasP(v:string, s:A): hasProperty(v,s) */
-/*@ qualif EnumP(v:string, s:A): enumProp(v,s)    */
+/*@ qualif HasP<A>(v:string, s:A): hasProperty(v,s) */
+/*@ qualif EnumP<A>(v:string, s:A): enumProp(v,s)    */
 
 /*@ values :: (map: [Immutable]{[k:string]: { number | v >= 0 }}) => MArray<{ number | v > 0 }> */
 function values(map:{[k:string]: number}): number[] {
 
   var values = [];
-  
+
   for (var key in map) {
     values.push(map[key]);
   }
-  
+
   return values;
 };

--- a/tests/pos/arrays/arr-09.ts
+++ b/tests/pos/arrays/arr-09.ts
@@ -2,10 +2,9 @@
 /*@ qualif Length(v:number): (len v) = 3 */
 
 /*@ a :: IArray<number> */
-var a = [1,2,3];
+var a = [1, 2, 3];
 
 /*@ b :: { IArray<number> | len v = 4 } */
 var b = [1,2,3,4];
- 
+
 assert(a.length + b.length === 7);
- 

--- a/tests/pos/arrays/arr-09.ts
+++ b/tests/pos/arrays/arr-09.ts
@@ -1,5 +1,3 @@
-//XXX: WORKS with this line - some qualifier scraping is missing...
-/*@ qualif Length(v:number): (len v) = 3 */
 
 /*@ a :: IArray<number> */
 var a = [1, 2, 3];

--- a/tests/pos/fb/minindex-modern-lib.ts
+++ b/tests/pos/fb/minindex-modern-lib.ts
@@ -3,14 +3,13 @@
 function minIndex(aa){
 
   /*@ readonly a :: # */
-  var a = aa; 
-  
+  var a = aa;
+
   if (a.length <= 0) return -1;
- 
-  function body(min: number, cur: number, i: number) { 
-      return cur < a[min] ? i : min; 
-  }; 
+
+  function body(acc: number, cur: number, i: number) {
+      return cur < a[acc] ? i : acc;
+  };
 
   return a.reduce(body, 0);
 }
-

--- a/tests/pos/fb/minindex-modern.ts
+++ b/tests/pos/fb/minindex-modern.ts
@@ -1,4 +1,4 @@
-/*@ alias index<a> = {v:number | 0 <= v && v < len a} */ 
+/*@ alias index<a> = {v:number | 0 <= v && v < len a} */
 
 
 // function reduce<T,A>(me: T[], callback:(x: A, y: T, n: number) => A, init:A): A
@@ -12,7 +12,7 @@ function reduce(me, callback, init) {
   for (var i = 0; i < me.length; i++){
     res = callback(res, me[i], i);
   }
-  
+
   return res;
 }
 
@@ -24,33 +24,10 @@ function minIndex(arrrr) {
     var arr = arrrr;
 
     if (arr.length <= 0) return -1;
-    
-    function body(min: number, cur: number, i: number) { 
-	    return cur < arr[min] ? i : min; 
-    }; 
-    
+
+    function body(acc: number, cur: number, i: number) {
+	    return cur < arr[acc] ? i : acc;
+    };
+
     return reduce(arr, body, 0);
 }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/tests/pos/inclusion/forin-00.ts
+++ b/tests/pos/inclusion/forin-00.ts
@@ -1,15 +1,15 @@
 
-/*@ qualif HasP(v:string, s:A): hasProperty(v,s) */
-/*@ qualif EnumP(v:string, s:A): enumProp(v,s)    */
+/*@ qualif HasP<A>(v:string, s:A): hasProperty(v,s) */
+/*@ qualif EnumP<A>(v:string, s:A): enumProp(v,s)    */
 
-/*@  values :: forall T . (map: [Immutable]{ [k:string]: T }) =>  { MArray<T> | true } */
-function values<T>(map:{[k:string]:T}): T[] {
-  
+/*@  values :: forall T . (mp: [Immutable]{ [k:string]: T }) =>  { MArray<T> | true } */
+function values<T>(mp:{[k:string]:T}): T[] {
+
   var values:T[] = [];
-  
-  for (var key in map) { 
-    values.push(<T>(map[key]));
+
+  for (var key in mp) {
+    values.push(<T>(mp[key]));
   }
-  
+
   return values;
 };

--- a/tests/pos/misc/minindex-00.ts
+++ b/tests/pos/misc/minindex-00.ts
@@ -1,22 +1,20 @@
-/*@ qualif UBound(v:number, x:a) : v < (len x) */
+/*@ qualif UBound<A>(v:number, x:A) : v < (len x) */
 
-/*@ loop :: (#Array[#Immutable,number], number, number) => number */ 
-function loop(b: number[], min: number, i: number): number {
+/*@ loop :: (#Array[#Immutable,number], number, number) => number */
+function loop(b: number[], acc: number, i: number): number {
   if (i < b.length) {
-    var min_ = min;
+    var acc_ = acc;
     assert(i < b.length);
-    if (b[i] < b[min]) { 
-      min_ = i; 
-  	} 
-    return loop(b, min_, i + 1)
+    if (b[i] < b[acc]) {
+      acc_ = i;
+  	}
+    return loop(b, acc_, i + 1)
   }
-  return min;
+  return acc;
 }
 
-/*@ minIndex :: ({a: #Array[#Immutable,number] | 0 < (len a)}) => {v:number | (0 <= v && v < (len a))} */ 
+/*@ minIndex :: ({a: #Array[#Immutable,number] | 0 < (len a)}) => {v:number | (0 <= v && v < (len a))} */
 function minIndex(a){
   var r = loop(a, 0, 0);
   return r;
 }
-
-

--- a/tests/pos/misc/minindex-01.ts
+++ b/tests/pos/misc/minindex-01.ts
@@ -1,5 +1,4 @@
-/*@ qualif UBound(v:number, x:a) : v < (len x) */
-
+/*@ qualif UBound<A>(v:number, x:A) : v < (len x) */
 /*@ predicate within(v,a) = (0 <= v && v < (len a)) */
 
 function forloop<A>(lo: number, hi: number, body: (x: number, y:A) => A, accum: A): A {
@@ -10,24 +9,21 @@ function forloop<A>(lo: number, hi: number, body: (x: number, y:A) => A, accum: 
 	return accum;
 }
 
-/*@ minIndex :: ({a: IArray<number> | 0 < (len a)}) => {v:number | within(v,a) } */ 
+/*@ minIndex :: ({a: IArray<number> | 0 < (len a)}) => {v:number | within(v,a) } */
 function minIndex(a:number[]):number{
 
   /*@ readonly aa :: # */
-  var aa = a; 
+  var aa = a;
 
   // XXX : MAKE SURE THE NESTED FUNCTIONS arguments BINDS, INDEED SHADOW THE
-  //       ENCLOSING FUNCTIONS ... 
-	
-	function step(i: number, min: number) {
-  if ( aa[i]
-  < 
-  aa[min]) { 
+  //       ENCLOSING FUNCTIONS ...
+
+	function step(i: number, acc: number) {
+  if ( aa[i] < aa[acc]) {
 			return i;
-		} 
-		return min; 
+		}
+		return acc;
 	}
 
 	return forloop(0, aa.length, step, 0);
-
 }

--- a/tests/pos/misc/minindex-02.ts
+++ b/tests/pos/misc/minindex-02.ts
@@ -1,4 +1,4 @@
-/*@ qualif UBound(v:number, x:a) : v < (len x) */
+/*@ qualif UBound<A>(v:number, x:A) : v < (len x) */
 
 /*@ range :: (number, number) => IArray<number> */
 function range(lo:number, hi:number) {
@@ -26,11 +26,11 @@ function minIndex(a){
   /*@ readonly aa :: # */
   var aa = a;
 
-	function step(i: number, min: number) {
-		if (aa[i] < aa[min]) {
+	function step(i: number, acc: number) {
+		if (aa[i] < aa[acc]) {
 			return i;
 		}
-		return min;
+		return acc;
 	};
 
 	return foldl(step, 0, range(0, aa.length));

--- a/tests/pos/objects/string-idx.ts
+++ b/tests/pos/objects/string-idx.ts
@@ -1,7 +1,7 @@
 
-/*@ qualif HasDP(v:string, s:a): hasDirectProperty(v,s) */
-/*@ qualif HasP(v:string, s:a): hasProperty(v,s)        */
-/*@ qualif EnumP(v:string, s:a): enumProp(v,s)          */
+/*@ qualif HasDP<A>(v:string, s:A): hasDirectProperty(v,s) */
+/*@ qualif HasP<A>(v:string, s:A): hasProperty(v,s)        */
+/*@ qualif EnumP<A>(v:string, s:A): enumProp(v,s)          */
 
 /*@ extend :: ( src:  [Immutable]{[s:string]: top }, dest: [Mutable]{[s:string]: top})
            => { [Mutable] {[s:string]: top } | true }

--- a/tests/pos/simple/arithmetic-option.ts
+++ b/tests/pos/simple/arithmetic-option.ts
@@ -1,9 +1,8 @@
 
-/*@ option REALS */
+/* option REALS */
 
-var a = 10; 
+var a = 10;
 
-var b = 20; 
+var b = 20;
 
 assert(a*a + b*b > 499);
-

--- a/tests/pos/simple/non-linear.ts
+++ b/tests/pos/simple/non-linear.ts
@@ -1,5 +1,5 @@
 
-/*@ option REALS */
+/* option "--real" */
 
 /*@ alias nat = {number | v >= 0} */
 

--- a/tests/test.hs
+++ b/tests/test.hs
@@ -53,10 +53,10 @@ testBinary = "rsc"
 type TestCmd = FilePath -> FilePath -> FilePath -> String
 ---------------------------------------------------------------------------
 rscCmd :: TestCmd
-rscCmd bin dir file = printf "cd %s && %s    %s" dir bin file
+rscCmd bin dir file = printf "cd %s && %s --native %s" dir bin file
 
 eCmd :: TestCmd
-eCmd bin dir file   = printf "cd %s && %s --extrainvs %s" dir bin file
+eCmd bin dir file   = printf "cd %s && %s --native --extrainvs %s" dir bin file
 
 
 ---------------------------------------------------------------------------

--- a/tests/test.hs
+++ b/tests/test.hs
@@ -53,10 +53,10 @@ testBinary = "rsc"
 type TestCmd = FilePath -> FilePath -> FilePath -> String
 ---------------------------------------------------------------------------
 rscCmd :: TestCmd
-rscCmd bin dir file = printf "cd %s && %s --native %s" dir bin file
+rscCmd bin dir file = printf "cd %s && %s %s" dir bin file
 
 eCmd :: TestCmd
-eCmd bin dir file   = printf "cd %s && %s --native --extrainvs %s" dir bin file
+eCmd bin dir file   = printf "cd %s && %s --extrainvs %s" dir bin file
 
 
 ---------------------------------------------------------------------------

--- a/tests/test.hs
+++ b/tests/test.hs
@@ -56,7 +56,7 @@ rscCmd :: TestCmd
 rscCmd bin dir file = printf "cd %s && %s    %s" dir bin file
 
 eCmd :: TestCmd
-eCmd bin dir file   = printf "cd %s && %s -e %s" dir bin file
+eCmd bin dir file   = printf "cd %s && %s --extrainvs %s" dir bin file
 
 
 ---------------------------------------------------------------------------


### PR DESCRIPTION
You can still run the old ocaml solver with `rsc --extsolver foo.ts`...